### PR TITLE
Replace local MongoDB role with external Ansible Galaxy dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ At least 2GB of memory and 3.5GB of disk space is required, since StackStorm is 
 
 ## Installation
 ```sh
+ansible-galaxy install -r roles/st2/requirements.yml
 ansible-playbook playbooks/st2express.yaml
 ```
 
@@ -27,6 +28,10 @@ Below is the list of variables you can redefine in your playbook to customize st
 | `st2_system_user`   | `stanley`     | System user on whose behalf st2 would work, including remote/local action runners.
 | `st2_auth_username` | `testu`       | Username used by StackStorm standalone authentication.
 | `st2_auth_password` | `testp`       | Password used by StackStorm standalone authentication.
+
+## Dependencies
+Ansible Galaxy roles used by StackStorm installation:
+ * [Stouts.mongodb](https://galaxy.ansible.com/list#/roles/982)
 
 ## Examples
 Install `stable` StackStorm with all its components on local machine:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provision :hostmanager
   end
 
+  # Ensure role dependencies are in place
+  if ['up', 'provision'].include?(ARGV.first) && !(File.directory?('roles/Stouts.mongodb'))
+    system('ansible-galaxy install -r roles/st2/requirements.yml')
+  end
+
   # Use rbconfig to determine if we're on a windows host or not.
   require 'rbconfig'
   is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)

--- a/playbooks/st2express.yaml
+++ b/playbooks/st2express.yaml
@@ -2,7 +2,6 @@
 - name: Install st2
   hosts: all
   roles:
-    - mongodb
     - rabbitmq
     - mysql
     - mistral

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -1,9 +1,0 @@
-- name: Install dependencies
-  sudo: true
-  apt:
-    name: "{{ item }}"
-    update_cache: yes
-    state: present
-  with_items:
-    - mongodb
-    - mongodb-server

--- a/roles/st2/meta/main.yml
+++ b/roles/st2/meta/main.yml
@@ -12,4 +12,7 @@ galaxy_info:
         - precise
   categories:
     - system
-dependencies: []
+dependencies:
+  - role: Stouts.mongodb
+    version: 2.1.10
+    tags: [db, mongo]

--- a/roles/st2/requirements.yml
+++ b/roles/st2/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: Stouts.mongodb
+  version: 2.1.10

--- a/roles/st2/tasks/1.requirements.yml
+++ b/roles/st2/tasks/1.requirements.yml
@@ -6,15 +6,15 @@
   when: ansible_memtotal_mb < st2_required_memory|int
   tags: [st2, requirements]
 
-# TODO: Trigger disc space check only for fresh install, handle cases when Mongo config is not default
+# TODO: Trigger disc space check only for fresh install
 - name: requirements | Get available disk space
-  shell: df -Pk /var/lib | grep -vE '^Filesystem|tmpfs|cdrom' | awk '{print $4}'
+  shell: df -Pk {{ mongodb_conf_dbpath }} | grep -vE '^Filesystem|tmpfs|cdrom' | awk '{print $4}'
   register: free_disk_space
   changed_when: False
   tags: [st2, requirements]
 
 - name: requirements | Check if there is enough disc space
   fail:
-    msg: "At least {{ st2_required_space }}MB in /var/lib is required for st2 installation!"
+    msg: "At least {{ st2_required_space }}MB in '{{ mongodb_conf_dbpath }}' is required by Mongo for st2 installation!"
   when: free_disk_space.stdout < st2_required_space
   tags: [st2, requirements]


### PR DESCRIPTION
Implements #9

Use **`Stouts.mongodb`** https://galaxy.ansible.com/list#/roles/982 as a dependency.

It installs MongoDB via recommended way: http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/ and also has basic TravisCI tests.
