### PR TITLE
Minimal CI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Ansible playbooks to deploy [StackStorm](https://github.com/stackstorm/st2).
 With over [50+ integrations](https://github.com/StackStorm/st2contrib/tree/master/packs) like GitHub, Docker, Nagios, NewRelic, AWS, Ansible it allows you to wire together your existing infrastructure into complex Workflows with auto-remediation and many more.
 Aka IFTTT orchestration for Ops.
 
+[![Circle CI Build Status](https://circleci.com/gh/StackStorm/ansible-st2/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/ansible-st2/tree/master)
+
 ## Supported platforms
 * Ubuntu 12.04
 * Ubuntu 14.04

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,4 @@
 machine:
-  python:
-    version: 2.7.6
   environment:
     ANSIBLE_FORCE_COLOR: 1
     PYTHONUNBUFFERED: 1

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
     PYTHONUNBUFFERED: 1
   pre:
     # use aptitude to remove dependencies
-    - sudo aptitude remove -y ~npostgresql
+    - sudo aptitude remove -y ~npostgresql-
     - sudo aptitude remove -y ~nrabbitmq
     - sudo aptitude remove -y ~nmongo
     - sudo aptitude remove -y ~nmysql-
@@ -22,3 +22,4 @@ test:
   override:
     - ansible-playbook -i inventory --syntax-check playbooks/st2express.yaml
     - ansible-playbook -i inventory --connection=local -vv playbooks/st2express.yaml
+    - st2 --version

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,19 @@
 machine:
+  python:
+    version: 2.7.6
   environment:
     ANSIBLE_FORCE_COLOR: 1
     PYTHONUNBUFFERED: 1
+  pre:
+    # use aptitude to remove dependencies
+    - sudo aptitude remove -y ~npostgresql
+    - sudo aptitude remove -y ~nrabbitmq
+    - sudo aptitude remove -y ~nmongo
+    - sudo aptitude remove -y ~nmysql-
 
 dependencies:
   cache_directories:
-    - '~/.cache/pip/'
+    - ~/.cache/pip
   pre:
     - sudo pip install ansible
     - ansible --version

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,6 @@
-machine:
-  python
-
 dependencies:
+  cache_directories:
+    - '~/.cache/pip/'
   pre:
     - sudo pip install ansible
     - ansible --version

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  python
+
+dependencies:
+  pre:
+    - sudo pip install ansible
+    - ansible --version
+
+test:
+  pre:
+    - echo localhost > inventory
+  override:
+    - ansible-playbook -i inventory --syntax-check playbooks/st2express.yaml
+    - ansible-playbook -i inventory --connection=local -vv playbooks/st2express.yaml

--- a/circle.yml
+++ b/circle.yml
@@ -4,14 +4,12 @@ machine:
     PYTHONUNBUFFERED: 1
   pre:
     # use aptitude to remove dependencies
-    - sudo aptitude remove -y ~npostgresql-
+    - sudo aptitude remove -y postgresql
     - sudo aptitude remove -y ~nrabbitmq
     - sudo aptitude remove -y ~nmongo
     - sudo aptitude remove -y ~nmysql-
 
 dependencies:
-  cache_directories:
-    - ~/.cache/pip
   pre:
     - sudo pip install ansible
     - ansible --version

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,8 @@
+machine:
+  environment:
+    ANSIBLE_FORCE_COLOR: 1
+    PYTHONUNBUFFERED: 1
+
 dependencies:
   cache_directories:
     - '~/.cache/pip/'

--- a/roles/mistral/tasks/install_deps.yml
+++ b/roles/mistral/tasks/install_deps.yml
@@ -12,5 +12,4 @@
     - libxslt1-dev
     - python-dev
     - python-pip
-    - python-virtualenv
     - libmysqlclient-dev

--- a/roles/st2/tasks/4.dependencies.yml
+++ b/roles/st2/tasks/4.dependencies.yml
@@ -9,8 +9,13 @@
     - git
     - python-dev
     - python-pip
-    - python-virtualenv
     - realpath
+  tags: [st2, dependencies]
+
+- name: dependencies | Install pip virtualenv
+  sudo: true
+  pip:
+    name: virtualenv
   tags: [st2, dependencies]
 
 - name: dependencies | Install st2 pip dependencies


### PR DESCRIPTION
Partially solves #7 

While the initial plan was bigger: Rspec Integration tests, Test-Kitchen, isolation, different linux distros to test,
it could be good to postpone it because of upcoming changes in st2 packaging and testing.

This PR includes very basic Playbook run under CircleCI.com (Circle is faster than Travis).
Good enough for current needs when playbooks only support Ubuntu. Progress in small steps.

So here we just check if playbook run is succeeded under Ubuntu 12.

-----

Not to forget: 
* CircleCI supports Docker
* [Travis now supports Docker too](http://blog.travis-ci.com/2015-08-19-using-docker-on-travis-ci/)
* KitchenCI:
  * [kitchen-docker](https://github.com/portertech/kitchen-docker)
  * [kitchen-vagrant](https://github.com/test-kitchen/kitchen-vagrant)
  * [kitchen-ansible](https://github.com/neillturner/kitchen-ansible)
* Docker way is not good enough for current environment with many services installed on single machine
* It's possible to run `lxc` containers under CircleCI
* [It's not possible to run `lxc` containers under Travis](https://travis-ci.org/armab/travis-lxc/builds)
* (!) [New Travis infra can run Virtualbox + Vagrant VMs, but only for x32 images](https://travis-ci.org/armab/travis-vagrant/builds/77223187) (email sent to Travis for further info)
* To dig further:
  * [Vagrant-lxc as KitchenCI driver under CircleCI](https://github.com/fgrehm/vagrant-lxc/issues/339)
  * [kitchen-lxc](https://github.com/chrisroberts/kitchen-lxc) under CircleCI
  * play with `lxc` containers under CircleCI ssh, try to build custom `lxc` templates
