### PR TITLE
Include pip virtualenv in mistral install

### DIFF
--- a/roles/mistral/tasks/install_deps.yml
+++ b/roles/mistral/tasks/install_deps.yml
@@ -13,3 +13,8 @@
     - python-dev
     - python-pip
     - libmysqlclient-dev
+
+- name: Install pip virtualenv
+  sudo: true
+  pip:
+    name: virtualenv


### PR DESCRIPTION
Fixes

```
TASK: [mistral | Install requirements] ****************************************
failed: [localhost] => {"failed": true}
msg: Failed to find required executable virtualenv 
```