### PR TITLE
Add dependency to libpq-dev for mistral

### DIFF
--- a/roles/mistral/tasks/install_deps.yml
+++ b/roles/mistral/tasks/install_deps.yml
@@ -13,6 +13,7 @@
     - python-dev
     - python-pip
     - libmysqlclient-dev
+    - libpq-dev
 
 - name: Install pip virtualenv
   sudo: true


### PR DESCRIPTION
Installing requirements for mistral fails with 'Error: pg_config executable not found.'
Tested with the ubuntu/trusty64 box, version 20150928.0.0