### PR TITLE
Upgrade pip

### DIFF
--- a/roles/st2/tasks/4.dependencies.yml
+++ b/roles/st2/tasks/4.dependencies.yml
@@ -12,6 +12,12 @@
     - realpath
   tags: [st2, dependencies]
 
+- name: dependencies | Upgrade pip
+  sudo: true
+  pip:
+    name: pip
+    extra_args: "-U"
+
 - name: dependencies | Install pip virtualenv
   sudo: true
   pip:


### PR DESCRIPTION
Installing st2 fails on 'Install st2 pip dependencies' with 'Upgrade pip, your version `1.5.4' is outdated'
Tested with the ubuntu/trusty64 box, version 20150928.0.0