### PR TITLE
Add sudo flag for ANXS.postgresql role

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,5 +23,5 @@ test:
     - echo localhost > inventory
   override:
     - ansible-playbook -i inventory --syntax-check playbooks/st2express.yaml
-    - sudo -E ansible-playbook -i inventory --connection=local -vv playbooks/st2express.yaml
+    - ansible-playbook -i inventory --connection=local -vv playbooks/st2express.yaml
     - st2 --version

--- a/roles/mistral/meta/main.yml
+++ b/roles/mistral/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: armab
   company: StackStorm
   license: Apache
-  min_ansible_version: 1.9
+  min_ansible_version: 1.9.1
   platforms:
     - name: Ubuntu
       versions:
@@ -16,6 +16,7 @@ dependencies:
   - role: ANXS.postgresql
     version: v1.2.1
     tags: [db, postgresql]
+    sudo: yes
     postgresql_databases:
       - name: mistral
     postgresql_users:


### PR DESCRIPTION
Fixes #27 

Also make sure Ansible version is >= 1.9.1 for this flag to work properly, see bug: https://github.com/ansible/ansible/issues/10550