### PR TITLE
Ensure that the /var/log/mistral dir exists

### DIFF
--- a/roles/mistral/tasks/install_mistral.yml
+++ b/roles/mistral/tasks/install_mistral.yml
@@ -23,3 +23,9 @@
   shell: /opt/openstack/mistral/.venv/bin/python setup.py install
   args:
     chdir: /opt/openstack/mistral
+
+- name: Create mistral log dir
+  sudo: true
+  file:
+    path: /var/log/mistral/
+    state: directory


### PR DESCRIPTION
Mistral wouldn't start on a clean vagrant box because the log dir didn't exist. This should solve that issue.