### PR TITLE
Rename `version` to `mistral_version`

### DIFF
--- a/roles/mistral/defaults/main.yml
+++ b/roles/mistral/defaults/main.yml
@@ -1,1 +1,1 @@
-version: 0.13
+mistral_version: 0.13

--- a/roles/mistral/tasks/gather_facts.yml
+++ b/roles/mistral/tasks/gather_facts.yml
@@ -1,5 +1,5 @@
 - name: Pick Mistral branch
   set_fact:
     mistral_branch: "{{ item.then }}"
-  when: "version | version_compare(item.if, operator='ge')"
+  when: "mistral_version | version_compare(item.if, operator='ge')"
   with_items: mistral_branches


### PR DESCRIPTION
`version` is **very** generic variable name for mistral version, resulting bugs reported in #community by @johandahlberg.

Avoid collisions, rename it.
