### PR TITLE
Fixed problems in installing mistral

### DIFF
--- a/roles/mistral/defaults/main.yml
+++ b/roles/mistral/defaults/main.yml
@@ -1,1 +1,1 @@
-version: 0.13
+mistral_version: 0.13

--- a/roles/mistral/tasks/gather_facts.yml
+++ b/roles/mistral/tasks/gather_facts.yml
@@ -1,5 +1,5 @@
 - name: Pick Mistral branch
   set_fact:
     mistral_branch: "{{ item.then }}"
-  when: "version | version_compare(item.if, operator='ge')"
+  when: "mistral_version | version_compare(item.if, operator='ge')"
   with_items: mistral_branches

--- a/roles/mistral/tasks/sync.yml
+++ b/roles/mistral/tasks/sync.yml
@@ -3,3 +3,4 @@
   args:
     chdir: /opt/openstack/mistral
     creates: /etc/mistral/database_setup.lock
+  sudo: yes

--- a/roles/mistral/tasks/sync.yml
+++ b/roles/mistral/tasks/sync.yml
@@ -1,5 +1,5 @@
 - name: Sync database
-  shell: /opt/openstack/mistral/.venv/bin/python ./tools/sync_db.py --config-file /etc/mistral/mistral.conf
+  shell: /opt/openstack/mistral/.venv/bin/python ./tools/sync_db.py --config-file /etc/mistral/mistral.conf && touch /etc/mistral/database_setup.lock
   args:
     chdir: /opt/openstack/mistral
     creates: /etc/mistral/database_setup.lock


### PR DESCRIPTION
I added a prefix to the mistral version, and I also added a `touch /etc/mistral/database_setup.lock` to make sure that the database is not populated twice.