### PR TITLE
Revision can be set manually and mistral config fixes

### DIFF
--- a/roles/mistral/defaults/main.yml
+++ b/roles/mistral/defaults/main.yml
@@ -1,1 +1,4 @@
 mistral_version: 0.13
+mistral_db_password: StackStorm
+mistral_db_server: localhost
+mistral_db: mistral

--- a/roles/mistral/defaults/main.yml
+++ b/roles/mistral/defaults/main.yml
@@ -1,5 +1,4 @@
 mistral_version: 0.13
-mistral_username: mistral
+mistral_db_username: mistral
 mistral_db_password: StackStorm
-mistral_db_server: localhost
 mistral_db: mistral

--- a/roles/mistral/defaults/main.yml
+++ b/roles/mistral/defaults/main.yml
@@ -1,4 +1,5 @@
 mistral_version: 0.13
+mistral_username: mistral
 mistral_db_password: StackStorm
 mistral_db_server: localhost
 mistral_db: mistral

--- a/roles/mistral/files/mistral.conf
+++ b/roles/mistral/files/mistral.conf
@@ -1,6 +1,0 @@
-[database]
-connection=postgresql://mistral:StackStorm@localhost/mistral
-max_pool_size=50
-
-[pecan]
-auth_enable=false

--- a/roles/mistral/meta/main.yml
+++ b/roles/mistral/meta/main.yml
@@ -18,8 +18,8 @@ dependencies:
     tags: [db, postgresql]
     sudo: yes
     postgresql_databases:
-      - name: mistral
+      - name: "{{ mistral_db }}"
     postgresql_users:
-      - name: mistral
-        pass: StackStorm
+      - name: "{{ mistral_db_username }}"
+        pass: "{{ mistral_db_password }}"
         encrypted: yes

--- a/roles/mistral/tasks/config.yml
+++ b/roles/mistral/tasks/config.yml
@@ -1,16 +1,10 @@
-- name: Copy Mistral config
+- name: Add Mistral config
   sudo: true
-  copy:
-    src: mistral.conf
+  template:
+    src: mistral.conf.j2
     dest: /etc/mistral/mistral.conf
-
-- name: Set mistral config values
-  sudo: true
-  ini_file:
-    dest=/etc/mistral/mistral.conf
-    section=database
-    option=connection
-    value=postgresql://mistral:{{mistral_db_password}}@{{mistral_db_server}}/{{mistral_db}}
+  notify:
+    - restart mistral
 
 - name: Copy Mistral log config
   sudo: true

--- a/roles/mistral/tasks/config.yml
+++ b/roles/mistral/tasks/config.yml
@@ -4,6 +4,14 @@
     src: mistral.conf
     dest: /etc/mistral/mistral.conf
 
+- name: Set mistral config values
+  sudo: true
+  ini_file:
+    dest=/etc/mistral/mistral.conf
+    section=database
+    option=connection
+    value=postgresql://mistral:{{mistral_db_password}}@{{mistral_db_server}}/{{mistral_db}}
+
 - name: Copy Mistral log config
   sudo: true
   command: cp /opt/openstack/mistral/etc/wf_trace_logging.conf.sample /etc/mistral/wf_trace_logging.conf creates=/etc/mistral/wf_trace_logging.conf

--- a/roles/mistral/templates/mistral.conf.j2
+++ b/roles/mistral/templates/mistral.conf.j2
@@ -1,0 +1,6 @@
+[database]
+connection=postgresql://{{ mistral_username }}:{{ mistral_db_password }}@{{ mistral_db_server }}}/{{ mistral_db }}
+max_pool_size=50
+
+[pecan]
+auth_enable=false

--- a/roles/mistral/templates/mistral.conf.j2
+++ b/roles/mistral/templates/mistral.conf.j2
@@ -1,5 +1,5 @@
 [database]
-connection=postgresql://{{ mistral_username }}:{{ mistral_db_password }}@{{ mistral_db_server }}}/{{ mistral_db }}
+connection=postgresql://{{ mistral_db_username }}:{{ mistral_db_password }}@localhost/{{ mistral_db }}
 max_pool_size=50
 
 [pecan]

--- a/roles/st2/defaults/main.yml
+++ b/roles/st2/defaults/main.yml
@@ -26,3 +26,8 @@ st2_action_runners: "{{ [ansible_processor_vcpus, 2] | max }}"
 
 st2_auth_username: testu
 st2_auth_password: testp
+
+# Set to no if you do not want the st2_system_user to be added in
+# the sudoers file.
+st2_system_user_in_sudoers: yes
+

--- a/roles/st2/tasks/2.version.yml
+++ b/roles/st2/tasks/2.version.yml
@@ -29,13 +29,6 @@
 - name: version | Lookup StackStorm revision to install
   set_fact:
     _st2_revision: "{{ lookup('url', 'https://downloads.stackstorm.net/releases/st2/' + _st2_version + '/debs/' + st2_revision + '/VERSION.txt') }}"
-  when: st2_revision == 'current'
-  tags: [st2, version]
-
-- name: version | Set which StackStorm revision to install manually
-  set_fact:
-    _st2_revision: {{ st2_revision }}
-  when: st2_revision != 'current'
   tags: [st2, version]
 
 - name: version | Gather StackStorm package info

--- a/roles/st2/tasks/2.version.yml
+++ b/roles/st2/tasks/2.version.yml
@@ -32,6 +32,12 @@
   when: st2_revision == 'current'
   tags: [st2, version]
 
+- name: version | Set which StackStorm revision to install manually
+  set_fact:
+    _st2_revision: {{ st2_revision }}
+  when: st2_revision != 'current'
+  tags: [st2, version]
+
 - name: version | Gather StackStorm package info
   command: dpkg -s st2common
   register: _st2_package_info

--- a/roles/st2/tasks/2.version.yml
+++ b/roles/st2/tasks/2.version.yml
@@ -1,6 +1,7 @@
 # StackStorm version checks and facts gathering
 # TODO: Rework as lookup plugin when Ansible 2.0 available: https://groups.google.com/forum/#!msg/ansible-devel/MF4TY-wa9Ww/mL9sVSMd5DwJ
 ---
+
 - name: version | Lookup literal version
   shell: >
     curl -Ss -q https://downloads.stackstorm.net/deb/pool/trusty_{{ st2_version }}/main/s/st2api/ |
@@ -28,7 +29,9 @@
 
 - name: version | Lookup StackStorm revision to install
   set_fact:
-    _st2_revision: "{{ lookup('url', 'https://downloads.stackstorm.net/releases/st2/' + _st2_version + '/debs/' + st2_revision + '/VERSION.txt') }}"
+      _st2_revision: "{{ item }}"
+  with_url:
+    - "https://downloads.stackstorm.net/releases/st2/{{ _st2_version }}/debs/{{ st2_revision }}/VERSION.txt"
   tags: [st2, version]
 
 - name: version | Gather StackStorm package info

--- a/roles/st2/tasks/3.user.yml
+++ b/roles/st2/tasks/3.user.yml
@@ -29,6 +29,6 @@
     mode: 0440
     regexp: "^{{ st2_system_user }} ALL="
     line: "{{ st2_system_user }} ALL=(ALL) NOPASSWD: SETENV: ALL"
-    state: present
+    state: "{{ 'present' if st2_system_user_in_sudoers else 'absent' }}"
     validate: 'visudo -cf %s'
   tags: [st2, user]


### PR DESCRIPTION
Two small fixes:
 - If the `st2_revision` was not set to `current` `_st2_revision` was not set and thus failed downstream.
 - Made it possible to configure some of the values for mistral, i.e. the password, server and db values.