### PR TITLE
Don't delegate version lookup to localhost

### DIFF
--- a/roles/st2/tasks/2.version.yml
+++ b/roles/st2/tasks/2.version.yml
@@ -11,7 +11,6 @@
     uniq | head -n 1
   when: st2_version == 'stable' or st2_version == 'unstable'
   register: _st2_version
-  delegate_to: 127.0.0.1
   changed_when: False
   tags: [st2, version]
 


### PR DESCRIPTION
Delegating version lookup to localhost breaks when the localhost doesn't have standard GNU coreutils (ie. on OSX)
Just run it on the remote host instead.

Fixes #36