### PR TITLE
Use correct APT syntax for specifying version revisions

### DIFF
--- a/roles/st2/tasks/main.yml
+++ b/roles/st2/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Install latest st2 package
   sudo: yes
   apt:
-    name: st2={{ st2_version }}.{{ st2_revision }}
+    name: st2={{ st2_version }}-{{ st2_revision }}
     state: present
   when: st2_version != "stable"
   notify:


### PR DESCRIPTION
Minor fix to use the correct syntax when specifying version revisions to apt. 