### PR TITLE
Switch to MongoDB 3.2 packages

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,9 @@ dependencies:
     - sudo apt-get install python-pip python-dev
     - sudo pip install --upgrade setuptools
     - sudo pip install ansible
+    # fix for Python SNI (Server Name Indication) verification
+    # https://github.com/ansible/ansible/issues/12161#issuecomment-136949743
+    - sudo pip install urllib3 pyopenssl ndg-httpsclient pyasn1
     - ansible --version
 
 test:

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -3,6 +3,7 @@
   sudo: yes
   apt_key:
     url: https://www.mongodb.org/static/pgp/server-3.2.asc
+    id: 42F3E95A2C4F08279C4960ADD68FA50FEA312927
     state: present
   tags: [databases, mongodb]
 

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -1,8 +1,22 @@
-- name: Install dependencies
-  sudo: true
+---
+- name: Add mongodb key
+  sudo: yes
+  apt_key:
+    url: https://www.mongodb.org/static/pgp/server-3.2.asc
+    state: present
+  tags: [databases, mongodb]
+
+- name: Add mongodb repository
+  sudo: yes
+  apt_repository:
+    repo: 'deb http://repo.mongodb.org/apt/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }}/mongodb-org/3.2 multiverse'
+    state: present
+  tags: [databases, mongodb]
+
+- name: Install mongodb
+  sudo: yes
   apt:
-    name: "{{ item }}"
+    name: mongodb-org
     update_cache: yes
     state: present
-  with_items:
-    - mongodb-server
+  tags: [databases, mongodb]


### PR DESCRIPTION
> Work on #49 

Since [StackStorm v1.6](https://stackstorm.com/2016/08/10/stackstorm-v1-6-0/), MongoDB `3.2` is the default supported version.
