### PR TITLE
Fix Ansible 2.1 become-unprivileged-user compatibility issue

### DIFF
--- a/roles/mistral/tasks/main.yml
+++ b/roles/mistral/tasks/main.yml
@@ -32,6 +32,8 @@
     - restart mistral
 
 - name: Initiate database
+  vars:
+      ansible_ssh_pipelining: true
   become: yes
   become_user: postgres
   shell: psql < /etc/mistral/init_mistral_db.SQL

--- a/roles/st2/tasks/user.yml
+++ b/roles/st2/tasks/user.yml
@@ -13,6 +13,8 @@
   tags: [st2, user]
 
 - name: user | Authorize key-based access for system user
+  vars:
+      ansible_ssh_pipelining: true
   sudo: yes
   sudo_user: "{{ st2_system_user }}"
   authorized_key:


### PR DESCRIPTION
Enable per task pipelining to fix issue with Ansible 2.1 [1], otherwise it
would faile with "Failed to set permissions on the temporary files
Ansible needs to create when becoming an unprivileged user."

[1] https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user"