### PR TITLE
Fix PostgreSQL build failure

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,7 +15,8 @@ provisioner:
     # For the moment only staging repos have Ubuntu Xenial st2 packages
     # TODO: Remove when Ubuntu Xenial packages are available in prod
     st2_pkg_repo: staging-stable
-  ansible_version: latest
+  require_pip: true
+  ansible_version: 2.1.2
   ansible_verbose: true
   ansible_verbosity: 2
   # TODO: Make sure Ansible playbooks are idepotent

--- a/playbooks/requirements.yml
+++ b/playbooks/requirements.yml
@@ -1,6 +1,10 @@
 ---
 - hosts: all
   tasks:
+  # See: https://github.com/StackStorm/ansible-st2/pull/55
+  - fail: msg="This playbook doesn't work with Ansible 2.2 or greater. Use 2.1 instead."
+    when: ansible_version.full >= "2.2"
+
   - name: Install galaxy dependencies
     command: ansible-galaxy install -r roles/mistral/requirements.yml
     delegate_to: 127.0.0.1

--- a/roles/mistral/meta/main.yml
+++ b/roles/mistral/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
     - system
 dependencies:
   - role: ANXS.postgresql
-    version: v1.2.1
+    version: v1.6.2
     tags: [db, postgresql]
     sudo: yes
     postgresql_databases:


### PR DESCRIPTION
Discovered in https://github.com/StackStorm/ansible-st2/pull/54

```sh
TASK [ANXS.postgresql : PostgreSQL | Make sure the PostgreSQL users are present] ***

       task path: /tmp/kitchen/roles/ANXS.postgresql/tasks/users.yml:8

       fatal: [localhost]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'unicode object' has no attribute 'name'\n\nThe error appears to have been in '/tmp/kitchen/roles/ANXS.postgresql/tasks/users.yml': line 8, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: PostgreSQL | Make sure the PostgreSQL users are present\n  ^ here\n"}
```

This is probably due to newer Ansible and older dependency.
Try to Update external dependency `ANXS.postgresql` to latest. 
