### PR TITLE
Update ANXS.postgresql for real

### DIFF
--- a/roles/mistral/meta/main.yml
+++ b/roles/mistral/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
     - system
 dependencies:
   - role: ANXS.postgresql
-    version: v1.6.2
+    version: v1.5.0
     tags: [db, postgresql]
     sudo: yes
     postgresql_databases:

--- a/roles/mistral/requirements.yml
+++ b/roles/mistral/requirements.yml
@@ -1,3 +1,3 @@
 ---
 - src: ANXS.postgresql
-  version: v1.6.2
+  version: v1.5.0

--- a/roles/mistral/requirements.yml
+++ b/roles/mistral/requirements.yml
@@ -1,3 +1,3 @@
 ---
 - src: ANXS.postgresql
-  version: v1.2.1
+  version: v1.6.2


### PR DESCRIPTION
See: https://github.com/StackStorm/ansible-st2/pull/55

Thanks @jvrplmlmn for pointing to that!

It looks even more messed. Latest ANXS.postgresql on GitHub is `v1.6.2`, while latest released on Galaxy is `v1.5.0`.

Pinning to version on galaxy.