### PR TITLE
Unpin Ansible version

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,8 +16,6 @@ provisioner:
     # For the moment only staging repos have Ubuntu Xenial st2 packages
     # TODO: Remove when Ubuntu Xenial packages are available in prod
     st2_pkg_repo: staging-stable
-  require_pip: true
-  ansible_version: 2.1.2
   ansible_verbose: true
   ansible_verbosity: 2
   # TODO: Make sure Ansible playbooks are idepotent

--- a/playbooks/requirements.yml
+++ b/playbooks/requirements.yml
@@ -1,10 +1,6 @@
 ---
 - hosts: all
   tasks:
-  # See: https://github.com/StackStorm/ansible-st2/pull/55
-  - fail: msg="This playbook doesn't work with Ansible 2.2 or greater. Use 2.1 instead."
-    when: ansible_version.full >= "2.2"
-
   - name: Install galaxy dependencies
     command: ansible-galaxy install -r roles/mistral/requirements.yml
     delegate_to: 127.0.0.1


### PR DESCRIPTION
So `ANXS.postgresql` role works with latest Ansible `v2.2.0`.
Back to normal.