### PR TITLE
 Rhel support: rabbitmq-server

### DIFF
--- a/roles/rabbitmq/meta/main.yml
+++ b/roles/rabbitmq/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  description: Install Rabbitmq-server
+  author: humblearner
+  company: StackStorm
+  license: Apache
+  min_ansible_version: 2.2
+  platforms:
+    - name: Ubuntu
+      versions:
+        - trusty
+        - xenial
+    - name: EL
+      versions:
+        - 6
+        - 7
+  categories:
+    - system

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- name: Install rabbitmq packages
+- name: Install rabbitmq packages on {{ ansible_distribution }}
   become: yes
-  apt:
+  package:
     name: rabbitmq-server
-    update_cache: yes
     state: present
+  tags: [rabbitmq]
   notify:
     - restart rabbitmq


### PR DESCRIPTION
- [x] centos6
- [x] centos7
- [x] xenial
- [x] rhel6 (aws)
- [x] rhel7

Output:

```
TASK [rabbitmq : Install rabbitmq packages on CentOS] **************************
changed: [default]

RUNNING HANDLER [rabbitmq : restart rabbitmq] **********************************
changed: [default]
```