### PR TITLE
Ensure rabbitmq is enabled and running

### DIFF
--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -1,9 +1,17 @@
 ---
-- name: Install rabbitmq packages on {{ ansible_distribution }}
+- name: Install rabbitmq package on {{ ansible_distribution }}
   become: yes
   package:
     name: rabbitmq-server
     state: present
-  tags: [rabbitmq]
   notify:
     - restart rabbitmq
+  tags: rabbitmq
+
+- name: Ensure rabbitmq is enabled and running
+  become: yes
+  service:
+    name: rabbitmq-server
+    enabled: yes
+    state: started
+  tags: rabbitmq


### PR DESCRIPTION
Just a small addition to check that `rabbitmq-server` service is enabled and started which is usually a [good practice](http://docs.ansible.com/ansible/playbooks_best_practices.html#task-and-handler-organization-for-a-role) after installing some service.

The thing I missed in https://github.com/StackStorm/ansible-st2/pull/70