### PR TITLE
Include meta for Galaxy install

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,3 @@
-# Meta which allows installing `ansible-st2` via ansible-galaxy
-# Workaround for `ansible.cfg` to find stackstorm roles:
-# [defaults]
-# roles_path = /etc/ansible/roles/:/etc/ansible/roles/stackstorm/roles/
 ---
 galaxy_info:
   description: Install StackStorm with all components and dependant services including RabbitMQ, MongoDB, PostgreSQL, nginx.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,3 +1,7 @@
+# Meta which allows installing `ansible-st2` via ansible-galaxy
+# Workaround for `ansible.cfg` to find stackstorm roles:
+# [defaults]
+# roles_path = /etc/ansible/roles/:/etc/ansible/roles/stackstorm/roles/
 ---
 galaxy_info:
   description: Install StackStorm with all components and dependant services including RabbitMQ, MongoDB, PostgreSQL, nginx.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,29 @@
+# Meta which allows installing `ansible-st2` via ansible-galaxy
+# Workaround for `ansible.cfg` to find stackstorm roles:
+# [defaults]
+# roles_path = /etc/ansible/roles/:/etc/ansible/roles/stackstorm/roles/
+---
+galaxy_info:
+  description: Install StackStorm with all components and dependant services including RabbitMQ, MongoDB, PostgreSQL, nginx.
+  author: armab
+  company: StackStorm
+  license: Apache 2.0
+  min_ansible_version: 2.2
+  platforms:
+    - name: Ubuntu
+      versions:
+        - trusty
+        - xenial
+  categories:
+    - ops
+    - devops
+    - automation
+    - remediation
+    - stackstorm
+    - st2
+    - st2web
+    - st2mistral
+    - rabbitmq
+    - mongodb
+    - postgresql
+    - nginx


### PR DESCRIPTION
Meta which allows installing `ansible-st2` repo via ansible-galaxy

```sh
ansible-galaxy install ...
```
And while `ansible-st2` is not a real single "role", since we store many roles in `roles/`, this workaround for `ansible.cfg` to find stackstorm roles in plays should work:
```ini
[defaults]
roles_path = /etc/ansible/roles/:/etc/ansible/roles/stackstorm/roles/
```
