### PR TITLE
Enable CI for CentOS6

### DIFF
--- a/.kitchen-docker/centos6/Dockerfile
+++ b/.kitchen-docker/centos6/Dockerfile
@@ -1,0 +1,13 @@
+FROM stackstorm/packagingtest:centos6
+
+RUN mkdir -p /var/run/sshd
+RUN useradd -d /home/<%= @username %> -m -s /bin/bash <%= @username %>
+RUN echo <%= "#{@username}:#{@password}" %> | chpasswd
+RUN echo '<%= @username %> ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN mkdir -p /home/<%= @username %>/.ssh
+RUN chown -R <%= @username %> /home/<%= @username %>/.ssh
+RUN chmod 0700 /home/<%= @username %>/.ssh
+RUN touch /home/<%= @username %>/.ssh/authorized_keys
+RUN chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys
+RUN chmod 0600 /home/<%= @username %>/.ssh/authorized_keys
+RUN echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,6 +33,12 @@ platforms:
       run_command: /sbin/init
       volume:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  # CentOS6 with sysV init
+  - name: centos-6
+    driver_config:
+      image: stackstorm/packagingtest:centos6
+      platform: centos
+      run_command: /usr/sbin/sshd -D
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,9 +36,8 @@ platforms:
   # CentOS6 with sysV init
   - name: centos-6
     driver_config:
-      dockerfile: .kitchen-docker/centos6/Dockerfile
-      image: stackstorm/packagingtest:centos6
       platform: centos
+      dockerfile: .kitchen-docker/centos6/Dockerfile
       run_command: /usr/sbin/sshd -D
 
 suites:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,6 +36,7 @@ platforms:
   # CentOS6 with sysV init
   - name: centos-6
     driver_config:
+      dockerfile: .kitchen-docker/centos6/Dockerfile
       image: stackstorm/packagingtest:centos6
       platform: centos
       run_command: /usr/sbin/sshd -D

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ env:
   - DISTRO=ubuntu-16
   - DISTRO=centos-6
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: DISTRO=centos-6
+
 script:
   # run kitchen tests (destroy, create, converge, setup, verify and destroy)
   - kitchen test ${DISTRO}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services: docker
 env:
   - DISTRO=ubuntu-14
   - DISTRO=ubuntu-16
+  - DISTRO=centos-6
 
 script:
   # run kitchen tests (destroy, create, converge, setup, verify and destroy)


### PR DESCRIPTION
> Implements https://github.com/StackStorm/ansible-st2/issues/69

Enable CI for `CentOS6` (`kitchen-docker` in TravisCI).

Additionally, we run the task with `allow_failures` in Travis until CentOS6 is fully supported by `ansible-st2` playbooks as part of https://github.com/StackStorm/ansible-st2/milestone/2 plan.
