### PR TITLE
Enable CentOS7 CI in Travis

### DIFF
--- a/.kitchen-docker/centos7/Dockerfile
+++ b/.kitchen-docker/centos7/Dockerfile
@@ -1,0 +1,13 @@
+FROM stackstorm/packagingtest:centos7
+
+RUN mkdir -p /var/run/sshd
+RUN useradd -d /home/<%= @username %> -m -s /bin/bash <%= @username %>
+RUN echo <%= "#{@username}:#{@password}" %> | chpasswd
+RUN echo '<%= @username %> ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN mkdir -p /home/<%= @username %>/.ssh
+RUN chown -R <%= @username %> /home/<%= @username %>/.ssh
+RUN chmod 0700 /home/<%= @username %>/.ssh
+RUN touch /home/<%= @username %>/.ssh/authorized_keys
+RUN chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys
+RUN chmod 0600 /home/<%= @username %>/.ssh/authorized_keys
+RUN echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys

--- a/.kitchen-docker/centos7/Dockerfile
+++ b/.kitchen-docker/centos7/Dockerfile
@@ -1,13 +1,3 @@
 FROM stackstorm/packagingtest:centos7
 
-RUN mkdir -p /var/run/sshd
-RUN useradd -d /home/<%= @username %> -m -s /bin/bash <%= @username %>
-RUN echo <%= "#{@username}:#{@password}" %> | chpasswd
-RUN echo '<%= @username %> ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-RUN mkdir -p /home/<%= @username %>/.ssh
-RUN chown -R <%= @username %> /home/<%= @username %>/.ssh
-RUN chmod 0700 /home/<%= @username %>/.ssh
-RUN touch /home/<%= @username %>/.ssh/authorized_keys
-RUN chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys
-RUN chmod 0600 /home/<%= @username %>/.ssh/authorized_keys
-RUN echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys
+RUN echo '<%= IO.read(@public_key).strip %>' >> /root/.ssh/authorized_keys

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -38,6 +38,14 @@ platforms:
       platform: centos
       dockerfile: .kitchen-docker/centos6/Dockerfile
       run_command: /usr/sbin/sshd -D
+  # CentOS7 with Systemd
+  - name: centos-7
+    driver_config:
+      platform: centos
+      dockerfile: .kitchen-docker/centos7/Dockerfile
+      run_command: /sbin/init
+      volume:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,6 +43,7 @@ platforms:
     driver_config:
       platform: centos
       dockerfile: .kitchen-docker/centos7/Dockerfile
+      # TODO: Use non-root user after updating upstream Docker image: https://github.com/StackStorm/st2-dockerfiles/issues/38
       username: root
       password: docker.io
       run_command: /sbin/init

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,6 +43,8 @@ platforms:
     driver_config:
       platform: centos
       dockerfile: .kitchen-docker/centos7/Dockerfile
+      username: root
+      password: docker.io
       run_command: /sbin/init
       volume:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ env:
   - DISTRO=ubuntu-14
   - DISTRO=ubuntu-16
   - DISTRO=centos-6
+  - DISTRO=centos-7
 
 matrix:
   fast_finish: true
   allow_failures:
     - env: DISTRO=centos-6
+    - env: DISTRO=centos-7
 
 script:
   # run kitchen tests (destroy, create, converge, setup, verify and destroy)


### PR DESCRIPTION
This implements #68 

Enable CI for `CentOS7` (`kitchen-docker` in TravisCI).

Allow CentOS7 build to fail in Travis until we fully implement platform support in Ansible playbooks as part of https://github.com/StackStorm/ansible-st2/milestone/2 plan.