### PR TITLE
Change default value to install Stackstorm latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,17 @@ Below is the list of variables you can redefine in your playbook to customize st
 
 | Variable              | Default       | Description  |
 | --------------------- | ------------- | ------------ |
+| **st2repo**
 | `st2_pkg_repo`        | `stable`      | StackStorm PackageCloud repository to install. [`stable`](https://packagecloud.io/StackStorm/stable/), [`unstable`](https://packagecloud.io/StackStorm/unstable/), [`staging-stable`](https://packagecloud.io/StackStorm/staging-stable/), [`staging-unstable`](https://packagecloud.io/StackStorm/staging-unstable/)
-| `st2_version`         | `stable`      | StackStorm version to install. Use latest `stable` to get automatic updates or pin it to numeric version like `1.4.0`.
+| **st2**
+| `st2_version`         | `latest`      | StackStorm version to install. Use latest `latest` to get automatic updates or pin it to numeric version like `2.1.1`.
 | `st2_revision`        | `1`           | StackStorm revision to install. Used only with pinned `st2_version`.
 | `st2_system_user`     | `stanley`     | System user on whose behalf st2 would work, including remote/local action runners.
 | `st2_system_user_in_sudoers` | `yes`| Add `st2_system_user` to the sudoers (recommended for most `st2` features to work).
 | `st2_auth_username`   | `testu`       | Username used by StackStorm standalone authentication.
 | `st2_auth_password`   | `testp`       | Password used by StackStorm standalone authentication.
+| **st2mistral**
+| `mistral_version`     | `latest`      | st2mistral version to install. Use latest `latest` to get automatic updates or pin it to numeric version like `2.1.1`.
 | `mistral_db`          | `mistral`     | PostgreSQL DB name for Mistral.
 | `mistral_db_username` | `mistral`     | PostgreSQL DB user for Mistral.
 | `mistral_db_password` | `StackStorm`  | PostgreSQL DB password for Mistral.
@@ -45,12 +49,12 @@ Install latest `stable` StackStorm with all its components on local machine:
 ansible-playbook stackstorm.yml -i 'localhost,' --connection=local
 ```
 
-> Note that keeping `stable` version is useful to update StackStorm by re-running playbook, since it will reinstall st2 if there is new version available.
+> Note that keeping `latest` version is useful to update StackStorm by re-running playbook, since it will reinstall st2 if there is new version available.
 This is default behavior. If you don't want updates - consider pinning version-revision numbers.
 
 Install specific numeric version of st2 with pinned revision number as well:
 ```sh
-ansible-playbook stackstorm.yml --extra-vars='st2_version=1.4.0 st2_revision=8'
+ansible-playbook stackstorm.yml --extra-vars='st2_version=2.1.1 st2_revision=8'
 ```
 
 ## Other Installers

--- a/roles/st2/defaults/main.yml
+++ b/roles/st2/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # StackStorm package repository in packagecloud: 'stable', 'unstable', 'staging-stable', 'staging-unstable'
 st2_pkg_repo: stable
-# 'stable' to get latest version or numeric like '1.4.0'
-st2_version: stable
+# 'latest' to get latest version or numeric like '2.1.1'
+st2_version: latest
 # used only if 'st2_version' is numeric
 st2_revision: 1
 

--- a/roles/st2/tasks/main.yml
+++ b/roles/st2/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
-
 - name: Install latest st2 package
   become: yes
   apt:
     name: st2
     state: latest
-  when: st2_version == "stable"
+  when: st2_version == "latest"
   notify:
     - restart st2
 
@@ -14,7 +13,7 @@
   apt:
     name: st2={{ st2_version }}-{{ st2_revision }}
     state: present
-  when: st2_version != "stable"
+  when: st2_version != "latest"
   notify:
     - restart st2
 

--- a/roles/st2mistral/defaults/main.yml
+++ b/roles/st2mistral/defaults/main.yml
@@ -1,4 +1,4 @@
-mistral_version: stable
+mistral_version: latest
 mistral_db_username: mistral
 mistral_db_password: StackStorm
 mistral_db: mistral

--- a/roles/st2mistral/tasks/main.yml
+++ b/roles/st2mistral/tasks/main.yml
@@ -12,7 +12,7 @@
   package:
     name: st2mistral
     state: latest
-  when: mistral_version == "stable"
+  when: mistral_version == "latest"
   tags: st2mistral
 
 - name: Install latest st2mistral
@@ -20,7 +20,7 @@
   package:
     name: st2mistral={{ mistral_version }}
     state: present
-  when: mistral_version != "stable"
+  when: mistral_version != "latest"
   tags: st2mistral
 
 - name: Configure mistral

--- a/roles/st2web/tasks/main.yml
+++ b/roles/st2web/tasks/main.yml
@@ -25,7 +25,7 @@
   apt:
     name: st2web
     state: latest
-  when: st2_version == "stable"
+  when: st2_version == "latest"
   notify:
     - restart st2
 
@@ -34,7 +34,7 @@
   apt:
     name: st2web={{ st2_version }}-{{ st2web_revision }}
     state: present
-  when: st2_version != "stable"
+  when: st2_version != "latest"
   notify:
     - restart st2
 


### PR DESCRIPTION
This PR changes the naming to install latest StackStorm version.

### Before: (confusing)
`st2_version=stable`
to install latest version of `st2`

### Now: (more obvious)
`st2_version=latest`
to install latest version of `st2`.

This is more user-friendly and doesn't collide with `st2_pkg_repo=stable`.

---
The reason why it was `stable` before comes from history with old `st2_deploy.sh` script: https://github.com/StackStorm/st2/blob/ed6fdb4043647b766551c25f365782a58abce019/tools/st2_deploy.sh#L112-L113

Use better and more clear and obvious naming now.