### PR TITLE
Enable Idempotence check

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,8 +13,7 @@ provisioner:
   roles_path: roles
   ansible_verbose: true
   ansible_verbosity: 2
-  # TODO: Make sure Ansible playbooks are idepotent
-  idempotency_test: false
+  idempotency_test: true
 
 platforms:
   # Ubuntu Trusty with Upstart

--- a/roles/st2smoketests/tasks/main.yml
+++ b/roles/st2smoketests/tasks/main.yml
@@ -5,21 +5,23 @@
   tags:
     - smoke-tests
 
-
 - name: Make sure packs are reloaded
   become: yes
   command: st2ctl reload --register-all
+  changed_when: no
   tags:
     - smoke-tests
 
 - name: st2 installed
   command: st2 --version
+  changed_when: no
   tags:
     - smoke-tests
 
 - name: get authentication token
   command: st2 auth {{ st2_auth_username }} -p {{ st2_auth_password }} -t
   register: st2_token
+  changed_when: no
   tags:
     - smoke-tests
 
@@ -28,11 +30,15 @@
   register: output
   until: output.stdout_lines|length > 1
   retries: 5
+  changed_when: no
+  tags:
+    - smoke-tests
 
 - name: st2 run core.local -- date -R
   command: st2 run core.local -- date -R
   environment:
     ST2_AUTH_TOKEN: "{{ st2_token.stdout }}"
+  changed_when: no
   tags:
     - smoke-tests
 
@@ -40,5 +46,6 @@
   uri:
     url: https://{{ ansible_hostname }}/
     validate_certs: no
+  changed_when: no
   tags:
     - smoke-tests


### PR DESCRIPTION
This PR enables Idempotence check in `Kitchen-Ansible` CI and closes #6.
It verifies that second playbook re-run ends with `changed=0 failed=0` result.

I'm glad this happened, since we removed external `ANXS.postgresql` dependency role :tada: 

Thanks to @humblearner PRs, everything is already prepared for this transition, I just had to enable the check and mark `st2smoketests` as changed: no.
