### PR TITLE
Don't update cache during package installs

### DIFF
--- a/roles/mongodb/tasks/mongodb_apt.yaml
+++ b/roles/mongodb/tasks/mongodb_apt.yaml
@@ -18,7 +18,6 @@
   become: yes
   apt:
     name: mongodb-org
-    update_cache: yes
     state: present
   notify: Restart mongod
   tags: [databases, mongodb]

--- a/roles/mongodb/tasks/mongodb_yum.yaml
+++ b/roles/mongodb/tasks/mongodb_yum.yaml
@@ -24,7 +24,6 @@
   become: yes
   yum:
     name: mongodb-org
-    update_cache: yes
     state: present
   notify:
     - Restart mongod

--- a/roles/st2repos/tasks/main.yml
+++ b/roles/st2repos/tasks/main.yml
@@ -1,12 +1,9 @@
 ---
-# tasks file for st2repos
-
 - name: Install prereqs
   become: yes
   apt:
     name: "{{ item }}"
     state: present
-    update_cache: yes
   with_items:
     - debian-archive-keyring
     - apt-transport-https


### PR DESCRIPTION
`update_cache` is equivalent of `apt-get/yum upgrade`.
With that flag set to `yes` we get "changed" state for task on playbook re-run (bad): 
```yaml
TASK [st2repos : Install prereqs] **********************************************
changed: [test.uswest2.stackstorm.net] => (item=[u'debian-archive-keyring', u'apt-transport-https'])
```

So we `update_cache` when adding repository and don't `update_cache` when installing the package itself.

