### PR TITLE
Fix Selinux module work for nginx role

### DIFF
--- a/roles/nginx/meta/main.yml
+++ b/roles/nginx/meta/main.yml
@@ -1,9 +1,9 @@
 ---
 galaxy_info:
-  description: Install nignx
+  description: Install nginx org
   author: humblearner
   company: StackStorm
-  license: Apache
+  license: Apache 2.0
   min_ansible_version: 2.2
   tags: nginx
   platforms:
@@ -16,4 +16,5 @@ galaxy_info:
         - 6
         - 7
   categories:
-    - system
+    - web
+    - nginx

--- a/roles/nginx/tasks/nginx_yum.yml
+++ b/roles/nginx/tasks/nginx_yum.yml
@@ -37,4 +37,5 @@
     name: httpd_can_network_connect
     state: yes
     persistent: yes
+  when: ansible_selinux.status == "enabled" and ansible_selinux.mode == "enforcing"
   tags: nginx

--- a/roles/nginx/tasks/nginx_yum.yml
+++ b/roles/nginx/tasks/nginx_yum.yml
@@ -1,11 +1,4 @@
 ---
-- name: Install dependencies for nginx
-  become: yes
-  yum:
-    name: libsemanage-python, libselinux-python
-    state: present
-  tags: nginx
-
 - name: Add nginx key
   become: yes
   rpm_key:
@@ -31,7 +24,14 @@
     state: present
   tags: nginx
 
-- name: Allow network access for nginx
+- name: Install dependencies for SELinux Ansible module
+  become: yes
+  yum:
+    name: libsemanage-python, libselinux-python
+    state: present
+  tags: nginx
+
+- name: Adjust SELinux to allow network access for nginx
   become: yes
   seboolean:
     name: httpd_can_network_connect

--- a/stackstorm.yml
+++ b/stackstorm.yml
@@ -5,9 +5,9 @@
     - mongodb
     - rabbitmq
     - postgresql
-    - nginx
     - st2repos
     - st2
     - st2mistral
+    - nginx
     - st2web
     - st2smoketests


### PR DESCRIPTION
Fixes the following error under `EL 6/7`: 
```yaml
TASK [nginx : Allow network access for nginx] **********************************
task path: /tmp/kitchen/roles/nginx/tasks/nginx_yum.yml:34
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "SELinux is disabled on this host."}
```

Also includes other cosmetic changes for `nginx` role.
