### PR TITLE
Added step to disable requiretty

### DIFF
--- a/roles/st2/tasks/user.yml
+++ b/roles/st2/tasks/user.yml
@@ -33,6 +33,14 @@
     validate: 'visudo -cf %s'
   tags: [st2, user]
 
+- name: Disable requiretty
+  become: yes
+  replace:
+    dest: "/etc/sudoers"
+    regexp: '^Defaults\s+\+?requiretty'
+    replace: '# Defaults requiretty'
+  when: st2_system_user_in_sudoers
+
 - name: Configure system user in /etc/st2/st2.conf
   become: yes
   ini_file:
@@ -50,10 +58,3 @@
     option: ssh_key_file
     value: "{{ _user.ssh_key_file }}"
     backup: yes
-
-- name: Disable requiretty
-  become: yes
-  replace:
-    dest: "/etc/sudoers"
-    regexp: '^Defaults\s+\+?requiretty'
-    replace: '# Defaults requiretty'

--- a/roles/st2/tasks/user.yml
+++ b/roles/st2/tasks/user.yml
@@ -40,6 +40,7 @@
     regexp: '^Defaults\s+\+?requiretty'
     replace: '# Defaults requiretty'
   when: st2_system_user_in_sudoers
+  tags: [st2, user]
 
 - name: Configure system user in /etc/st2/st2.conf
   become: yes

--- a/roles/st2/tasks/user.yml
+++ b/roles/st2/tasks/user.yml
@@ -33,7 +33,6 @@
     validate: 'visudo -cf %s'
   tags: [st2, user]
 
-
 - name: Configure system user in /etc/st2/st2.conf
   become: yes
   ini_file:
@@ -51,3 +50,10 @@
     option: ssh_key_file
     value: "{{ _user.ssh_key_file }}"
     backup: yes
+
+- name: Disable requiretty
+  become: yes
+  replace:
+    dest: "/etc/sudoers"
+    regexp: '^Defaults\s+\+?requiretty'
+    replace: '# Defaults requiretty'


### PR DESCRIPTION
The current `st2` role does not disable the "requiretty" option in `/etc/sudoers`, which is a required step for setting up stackstorm, and as a result, the `st2smoketest` role was failing when it was time to run st2 commands:

```
[ec2-user@ip-10-0-4-218 ~]$ st2 run core.local_sudo -- date -R
.
id: 58866ee4ddd8ff29343e2d1b
status: failed
parameters:
  cmd: date -R
result:
  failed: true
  return_code: 1
  stderr: 'sudo: sorry, you must have a tty to run sudo'
  stdout: ''
  succeeded: false
[ec2-user@ip-10-0-4-218 ~]$
```

This PR introduces this step in the configuration.