### PR TITLE
Changed webui smoke test to simply use localhost

### DIFF
--- a/roles/st2smoketests/tasks/main.yml
+++ b/roles/st2smoketests/tasks/main.yml
@@ -44,7 +44,7 @@
 
 - name: Check web-ui is up
   uri:
-    url: https://{{ ansible_hostname }}/
+    url: https://localhost/
     validate_certs: no
   changed_when: no
   tags:


### PR DESCRIPTION
The previous variable resulted in a hostname that was unknown to the remote node, (at least when running in AWS) and this test failed.

Since this test is intended to take place on the node where stackstorm is installed/running, localhost should work fine.