### PR TITLE
Fix task include in postgresql role

### DIFF
--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
 - name: Install PostgreSQL on {{ ansible_distribution }}-{{ ansible_distribution_major_version }}
-  include: roles/postgresql/tasks/postgresql_{{ ansible_pkg_mgr }}{{ ansible_distribution_major_version }}.yml
+  include: postgresql_{{ ansible_pkg_mgr }}{{ ansible_distribution_major_version }}.yml
   tags: [db, postgresql]
   when: ansible_os_family == "RedHat"
 
 - name: Install PostgreSQL on {{ ansible_distribution }}-{{ ansible_distribution_major_version }}
-  include: roles/postgresql/tasks/postgresql_{{ ansible_pkg_mgr }}.yml
+  include: postgresql_{{ ansible_pkg_mgr }}.yml
   tags: [db, postgresql]
   when: ansible_os_family == "Debian"
-


### PR DESCRIPTION
Actual error:
```
FAILED! => {"failed": true, "reason": "the file_name '...roles/postgresql/tasks/postgresql_apt.yml' does not exist, or is not readable"}
```