### PR TITLE
Save credentials in .st2/config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Below is the list of variables you can redefine in your playbook to customize st
 | `st2_auth_enable`        | `yes`         | Enable StackStorm standalone authentication.
 | `st2_auth_username`      | `testu`       | Username used by StackStorm standalone authentication.
 | `st2_auth_password`      | `testp`       | Password used by StackStorm standalone authentication.
+| `st2_save_credentials`   | `yes`         | Save credentials for local CLI in `/root/.st2/config` file.
 | **st2mistral**
 | `st2mistral_version`     | `latest`      | st2mistral version to install. Use latest `latest` to get automatic updates or pin it to numeric version like `2.1.1`.
 | `st2mistral_db`          | `mistral`     | PostgreSQL DB name for Mistral.

--- a/roles/st2/defaults/main.yml
+++ b/roles/st2/defaults/main.yml
@@ -19,3 +19,5 @@ st2_auth_enable: yes
 st2_auth_username: testu
 # Password used by StackStorm standalone authentication
 st2_auth_password: testp
+# Save credentials in ~/.st2/config file
+st2_save_credentials: yes

--- a/roles/st2/tasks/auth.yml
+++ b/roles/st2/tasks/auth.yml
@@ -41,7 +41,10 @@
     - restart st2stream
 
 - name: auth | Create root's CLI configuration directory
-  file: path=/root/.st2 state=directory
+  become: yes
+  file:
+    path: /root/.st2
+    state: directory
   when: st2_save_credentials
 
 - name: auth | Save credentials in CLI configuration file
@@ -49,6 +52,9 @@
   blockinfile:
     dest: /root/.st2/config
     create: yes
+    mode: 0700
+    owner: root
+    group: root
     block: |
       [credentials]
       username = {{ st2_auth_username }}

--- a/roles/st2/tasks/auth.yml
+++ b/roles/st2/tasks/auth.yml
@@ -52,7 +52,7 @@
   blockinfile:
     dest: /root/.st2/config
     create: yes
-    mode: 0700
+    mode: 0600
     owner: root
     group: root
     block: |

--- a/roles/st2/tasks/auth.yml
+++ b/roles/st2/tasks/auth.yml
@@ -39,3 +39,18 @@
   notify:
     - restart st2api
     - restart st2stream
+
+- name: auth | Create root's CLI configuration directory
+  file: path=/root/.st2 state=directory
+  when: st2_save_credentials
+
+- name: auth | Save credentials in CLI configuration file
+  become: yes
+  blockinfile:
+    dest: /root/.st2/config
+    create: yes
+    block: |
+      [credentials]
+      username = {{ st2_auth_username }}
+      password = {{ st2_auth_password }}
+  when: st2_save_credentials


### PR DESCRIPTION
Save user credentials for `root` in `/root/.st2/config` as [installer script does](https://github.com/StackStorm/st2-packages/blob/master/scripts/st2bootstrap-deb.sh#L397-L401)

It is convenient to have the system ready-to-use after install, but if one doesn't like it, turn off by `st2_save_credentials: no`. 