### PR TITLE
Move virtualhost dirs management from `st2web` to `nginx` role

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,7 +1,26 @@
 ---
-# tasks file for nginx
 - name: Install nginx on {{ ansible_distribution }}
   include: nginx_{{ ansible_pkg_mgr }}.yml
+  tags: nginx
+
+- name: Create common virtual host folders
+  become: yes
+  file:
+    state: directory
+    path: "{{ item }}"
+  with_items:
+    - /etc/nginx/sites-available/
+    - /etc/nginx/sites-enabled/
+  tags: nginx
+
+- name: Ensure site-enabled is loaded
+  become: yes
+  lineinfile:
+    state: present
+    dest: /etc/nginx/nginx.conf
+    regexp: 'include /etc/nginx/sites-enabled/'
+    insertafter: '    include /etc/nginx/conf.d/'
+    line: 'include /etc/nginx/sites-enabled/*;'
   tags: nginx
 
 - name: Start & Enable nginx

--- a/roles/nginx/tasks/nginx_apt.yml
+++ b/roles/nginx/tasks/nginx_apt.yml
@@ -20,3 +20,10 @@
     name: nginx
     state: present
   tags: nginx
+
+- name: Remove default site
+  become: yes
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+  tags: nginx

--- a/roles/nginx/tasks/nginx_yum.yml
+++ b/roles/nginx/tasks/nginx_yum.yml
@@ -24,6 +24,13 @@
     state: present
   tags: nginx
 
+- name: Remove default site
+  become: yes
+  file:
+    path: /etc/nginx/conf.d/default.conf
+    state: absent
+  tags: nginx
+
 - name: Install dependencies for SELinux Ansible module
   become: yes
   yum:

--- a/roles/st2web/tasks/main.yml
+++ b/roles/st2web/tasks/main.yml
@@ -31,14 +31,6 @@
     - restart nginx
   tags: st2web
 
-- name: Remove default site
-  become: yes
-  file:
-    path: /etc/nginx/sites-enabled/default
-    state: absent
-  tags: st2web
-  when: ansible_distribution == "Ubuntu"
-
 - name: Copy Nginx config
   become: yes
   command: cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/sites-available/

--- a/roles/st2web/tasks/main.yml
+++ b/roles/st2web/tasks/main.yml
@@ -39,26 +39,6 @@
   tags: st2web
   when: ansible_distribution == "Ubuntu"
 
-- name: Create nginx folders
-  become: yes
-  file:
-    state: directory
-    path: "{{ item }}"
-  with_items:
-    - /etc/nginx/sites-available/
-    - /etc/nginx/sites-enabled/
-  tags: st2web
-
-- name: Ensure site-available is loaded
-  become: yes
-  lineinfile:
-    state: present
-    dest: /etc/nginx/nginx.conf
-    regexp: 'include /etc/nginx/sites-enabled/'
-    insertafter: '    include /etc/nginx/conf.d/'
-    line: 'include /etc/nginx/sites-enabled/*;'
-  tags: st2web
-
 - name: Copy Nginx config
   become: yes
   command: cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/sites-available/


### PR DESCRIPTION
The logic of creating `available` and `enabled` virtualhost dirs should be part of `nginx` role itself, not `st2web`.
Theoretically we could re-use `nginx` role in future.