### PR TITLE
Re-Enabling per task pipelining

### DIFF
--- a/roles/st2/tasks/user.yml
+++ b/roles/st2/tasks/user.yml
@@ -12,6 +12,8 @@
   register: _user
 
 - name: user | Authorize key-based access for system user
+  vars:
+      ansible_ssh_pipelining: true
   become: yes
   become_user: "{{ st2_system_user }}"
   authorized_key:

--- a/roles/st2mistral/tasks/main.yml
+++ b/roles/st2mistral/tasks/main.yml
@@ -32,6 +32,8 @@
   tags: st2mistral
 
 - name: Initiate mistral database
+  vars:
+      ansible_ssh_pipelining: true
   become: yes
   become_user: postgres
   shell: psql < /etc/mistral/init_mistral_db.SQL


### PR DESCRIPTION
Bringing back fix https://github.com/StackStorm/ansible-st2/commit/11129e980327ac9f32d108ce129abef66cc3612f

Currently hitting error:
~~~
TASK [st2 : user | Authorize key-based access for system user] *****************
fatal: [10.254.2.12]: FAILED! => {"failed": true, "msg": "Failed to set permissions on the temporary files Ansible needs t                           o create when becoming an unprivileged user (rc: 1, err: chown: changing ownership of '/tmp/ansible-tmp-1485779578.73-1856                           62873622578/': Operation not permitted\nchown: changing ownership of '/tmp/ansible-tmp-1485779578.73-185662873622578/autho                           rized_key.py': Operation not permitted\n). For information on working around this, see https://docs.ansible.com/ansible/be                           come.html#becoming-an-unprivileged-user"}
        to retry, use: --limit @/home/brocade/ansible/ops-infra/test.stackstorm.net.retry
~~~