### PR TITLE
Unstable repo in Build matrix

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,7 +15,7 @@ provisioner:
   ansible_verbosity: 2
   idempotency_test: true
   extra_vars:
-    st2_pkg_repo: <%= ENV['ST2_REPO'] || stable %>
+    st2_pkg_repo: <%= ENV['ST2_REPO'] || 'stable' %>
 
 platforms:
   # Ubuntu Trusty with Upstart

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,8 @@ provisioner:
   ansible_verbose: true
   ansible_verbosity: 2
   idempotency_test: true
+  extra_vars:
+    st2_pkg_repo: <%= ENV['ST2_REPO'] || stable %>
 
 platforms:
   # Ubuntu Trusty with Upstart

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,19 @@ branches:
     - master
 
 env:
-  # unstable repo check
-  - DISTRO=ubuntu-14 ST2_REPO=unstable
-  - DISTRO=ubuntu-14 ST2_REPO=unstable
-  - DISTRO=ubuntu-16 ST2_REPO=unstable
-  - DISTRO=centos-6 ST2_REPO=unstable
-  - DISTRO=centos-7 ST2_REPO=unstable
-
+  # default is stable repo
   - DISTRO=ubuntu-14
   - DISTRO=ubuntu-14
   - DISTRO=ubuntu-16
   - DISTRO=centos-6
   - DISTRO=centos-7
+
+  # StackStorm 'unstable' repo check
+  - DISTRO=ubuntu-14 ST2_REPO=unstable
+  - DISTRO=ubuntu-14 ST2_REPO=unstable
+  - DISTRO=ubuntu-16 ST2_REPO=unstable
+  - DISTRO=centos-6 ST2_REPO=unstable
+  - DISTRO=centos-7 ST2_REPO=unstable
 
 script:
   # run kitchen tests (destroy, create, converge, setup, verify and destroy)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ branches:
     - master
 
 env:
+  # unstable repo check
+  - DISTRO=ubuntu-14 ST2_REPO=unstable
+  - DISTRO=ubuntu-14 ST2_REPO=unstable
+  - DISTRO=ubuntu-16 ST2_REPO=unstable
+  - DISTRO=centos-6 ST2_REPO=unstable
+  - DISTRO=centos-7 ST2_REPO=unstable
+
+  - DISTRO=ubuntu-14
   - DISTRO=ubuntu-14
   - DISTRO=ubuntu-16
   - DISTRO=centos-6


### PR DESCRIPTION
As sugested by @dzimine in https://github.com/StackStorm/ansible-st2/issues/103, adding `unstable` PackageCloud repo to the Travis Build Matrix.

This will force us to pick up `st2`/`st2mistral` package configuration fixes early.