### PR TITLE
Remove duplicated distros from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,11 @@ branches:
 env:
   # default is stable repo
   - DISTRO=ubuntu-14
-  - DISTRO=ubuntu-14
   - DISTRO=ubuntu-16
   - DISTRO=centos-6
   - DISTRO=centos-7
 
   # StackStorm 'unstable' repo check
-  - DISTRO=ubuntu-14 ST2_REPO=unstable
   - DISTRO=ubuntu-14 ST2_REPO=unstable
   - DISTRO=ubuntu-16 ST2_REPO=unstable
   - DISTRO=centos-6 ST2_REPO=unstable


### PR DESCRIPTION
Tiny change to remove duplicated `DISTRO`s from `.travis.yml` previously added by mistake.