### PR TITLE
Revert "Fix to circumvent pbr related bug in mistral-db-manage populate"

### DIFF
--- a/roles/st2mistral/tasks/main.yml
+++ b/roles/st2mistral/tasks/main.yml
@@ -74,8 +74,7 @@
 
 - name: Register mistral actions
   become: yes
-  # Temporary workaround with `git init` until upstream `mistral` is fixed, see: https://github.com/StackStorm/st2-packages/pull/411
-  shell: git init && /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate && rm -rf .git && touch /etc/mistral/mistral-db-manage.populate.ansible.has.run
+  shell: /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate && touch /etc/mistral/mistral-db-manage.populate.ansible.has.run
   args:
     creates: /etc/mistral/mistral-db-manage.populate.ansible.has.run
   notify:


### PR DESCRIPTION
Reverts StackStorm/ansible-st2#109 temporary workaround.

Follow-up: https://github.com/StackStorm/st2-packages/pull/416 since bug is fixed in upstream.