### PR TITLE
Update CentOS Docker images endpoints

### DIFF
--- a/.kitchen-docker/centos6/Dockerfile
+++ b/.kitchen-docker/centos6/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackstorm/packagingtest:centos6
+FROM stackstorm/packagingtest:centos6-sshd
 
 RUN mkdir -p /var/run/sshd
 RUN useradd -d /home/<%= @username %> -m -s /bin/bash <%= @username %>

--- a/.kitchen-docker/centos7/Dockerfile
+++ b/.kitchen-docker/centos7/Dockerfile
@@ -1,3 +1,13 @@
-FROM stackstorm/packagingtest:centos7
+FROM stackstorm/packagingtest:centos7-systemd
 
-RUN echo '<%= IO.read(@public_key).strip %>' >> /root/.ssh/authorized_keys
+RUN mkdir -p /var/run/sshd
+RUN useradd -d /home/<%= @username %> -m -s /bin/bash <%= @username %>
+RUN echo <%= "#{@username}:#{@password}" %> | chpasswd
+RUN echo '<%= @username %> ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN mkdir -p /home/<%= @username %>/.ssh
+RUN chown -R <%= @username %> /home/<%= @username %>/.ssh
+RUN chmod 0700 /home/<%= @username %>/.ssh
+RUN touch /home/<%= @username %>/.ssh/authorized_keys
+RUN chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys
+RUN chmod 0600 /home/<%= @username %>/.ssh/authorized_keys
+RUN echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -44,9 +44,6 @@ platforms:
     driver_config:
       platform: centos
       dockerfile: .kitchen-docker/centos7/Dockerfile
-      # TODO: Use non-root user after updating upstream Docker image: https://github.com/StackStorm/st2-dockerfiles/issues/38
-      username: root
-      password: docker.io
       run_command: /sbin/init
       volume:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
Revert temporary workaround from https://github.com/StackStorm/ansible-st2/pull/82#discussion_r96282814 to use `root` in CentOS7 docker container.

It's possible since we're building `packagingtest` https://hub.docker.com/r/stackstorm/packagingtest/ Docker images automatically on every push to [st2-dockerfiles](https://github.com/StackStorm/st2-dockerfiles/tree/master/packagingtest) repo and can fix upstream images more easily.

See: https://github.com/StackStorm/st2-packages/pull/417 and https://github.com/StackStorm/st2-dockerfiles/issues/38 for more info