### PR TITLE
Switch to autogenerated 'packagingtest' Docker images

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,14 +21,14 @@ platforms:
   # Ubuntu Trusty with Upstart
   - name: ubuntu-14.04
     driver_config:
-      image: stackstorm/packagingtest:trusty
+      image: stackstorm/packagingtest:trusty-upstart
       platform: ubuntu
       disable_upstart: false
       run_command: /sbin/init
   # Ubuntu Xenial with Systemd
   - name: ubuntu-16.04
     driver_config:
-      image: stackstorm/packagingtest:xenial
+      image: stackstorm/packagingtest:xenial-systemd
       platform: ubuntu
       run_command: /sbin/init
       volume:


### PR DESCRIPTION
Follow-up for https://github.com/StackStorm/ansible-st2/pull/115

Since we generate `packagingtest` https://hub.docker.com/r/stackstorm/packagingtest/tags/ Docker images on every push to [st2-dockerfiles](https://github.com/StackStorm/st2-dockerfiles/tree/master/packagingtest) automatically, - switch to new images to test StackStorm installation in Test-Kitchen & Travis.
