### PR TITLE
Vagrantfile fixes & enhancements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,19 +4,19 @@
 VAGRANTFILE_API_VERSION = '2'
 VIRTUAL_MACHINES = {
   :ubuntu14 => {
-    :hostname => 'ubuntu14',
+    :hostname => 'ansible-st2-ubuntu14',
     :box => 'ubuntu/trusty64',
   },
   :ubuntu16 => {
-    :hostname => 'ubuntu16',
+    :hostname => 'ansible-st2-ubuntu16',
     :box => 'ubuntu/xenial64',
   },
   :centos6 => {
-    :hostname => 'centos6',
+    :hostname => 'ansible-st2-centos6',
     :box => 'centos/6',
   },
   :centos7 => {
-    :hostname => 'centos7',
+    :hostname => 'ansible-st2-centos7',
     :box => 'centos/7',
   },
 }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,18 +50,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vm_config.vm.provision :hostmanager
       end
 
-      if vm_config.vm.hostname.include? "ubuntu"
-        # Install Ansible native packages so the Ansible provisioner will work on systems
-        # without Python 2.7 (i.e. Xenial)
-        vm_config.vm.provision "shell",
-          inline: "sudo apt-add-repository -y ppa:ansible/ansible; sudo apt-get update; sudo apt-get install -y ansible"
-      end
-      if vm_config.vm.hostname.include? "centos"
-        vm_config.vm.provision "shell",
-          inline: "sudo yum -y install epel-release; sudo yum -y install ansible git"
-      end
-
-      vm_config.vm.provision :ansible do |ansible|
+      vm_config.vm.provision :ansible_local do |ansible|
+        ansible.install = true
         ansible.playbook = "stackstorm.yml"
       end
     end


### PR DESCRIPTION
1) Fix:
```
A VirtualBox machine with the name 'ubuntu16' already exists.
Please use another name or delete the machine with the existing
name, and try again.
```
by prefixing `vb.name` with `ansible-st2`.

2) Replace shell provisioner with `ansible_local` to install Ansible on a guest VM (cc @Mierdin).