### PR TITLE
Add tasks for setting up a rabbitmq cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Below is the list of variables you can redefine in your playbook to customize st
 | `st2mistral_db`          | `mistral`     | PostgreSQL DB name for Mistral.
 | `st2mistral_db_username` | `mistral`     | PostgreSQL DB user for Mistral.
 | `st2mistral_db_password` | `StackStorm`  | PostgreSQL DB password for Mistral.
+| **rabbitmq**
+| `rabbitmq_erlang_cookie` | `st2-mq`      | RabbitMQ security string to permit to communicate with each nodes in a cluster
 
 ## Examples
 Install latest `stable` StackStorm with all its components on local machine:

--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -1,0 +1,2 @@
+# RabbitMQ security string to permit to communicate with each nodes in a cluster
+rabbitmq_erlang_cookie: st2-mq

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -8,6 +8,21 @@
     - restart rabbitmq
   tags: rabbitmq
 
+- name: Stop rabbitmq for setting .erlang.cookie
+  become: yes
+  service:
+    name: rabbitmq-server
+    enabled: yes
+    state: stopped
+  tags: rabbitmq
+
+- name: Set erlang cookie for the rabbitmq
+  become: yes
+  copy:
+    content={{ rabbitmq_erlang_cookie }}
+    dest=/var/lib/rabbitmq/.erlang.cookie
+  tags: rabbitmq
+
 - name: Ensure rabbitmq is enabled and running
   become: yes
   service:


### PR DESCRIPTION
This is the implementation for #119

This patch added a task that wrote shared value to the `.erlang.cookie` file for setting up a RabbitMQ cluster.
When a couple of RabbitMQ servers are deployed by this role, user can easily set it up by this patch.