### PR TITLE
add proxy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Below is the list of variables you can redefine in your playbook to customize st
 | ------------------------ | ------------- | ------------ |
 | **st2repo**
 | `st2_pkg_repo`           | `stable`      | StackStorm PackageCloud repository to install. [`stable`](https://packagecloud.io/StackStorm/stable/), [`unstable`](https://packagecloud.io/StackStorm/unstable/), [`staging-stable`](https://packagecloud.io/StackStorm/staging-stable/), [`staging-unstable`](https://packagecloud.io/StackStorm/staging-unstable/)
+| `st2_proxies`             | `{}`         | Dictionary for http_proxy and https_proxy environment variables.
 | **st2**
 | `st2_version`            | `latest`      | StackStorm version to install. Use latest `latest` to get automatic updates or pin it to numeric version like `2.1.1`.
 | `st2_revision`           | `1`           | StackStorm revision to install. Used only with pinned `st2_version`.
@@ -42,11 +43,23 @@ Below is the list of variables you can redefine in your playbook to customize st
 | `st2_auth_username`      | `testu`       | Username used by StackStorm standalone authentication.
 | `st2_auth_password`      | `testp`       | Password used by StackStorm standalone authentication.
 | `st2_save_credentials`   | `yes`         | Save credentials for local CLI in `/root/.st2/config` file.
+| `st2_proxies`             | `{}`         | Dictionary for http_proxy and https_proxy environment variables.
 | **st2mistral**
 | `st2mistral_version`     | `latest`      | st2mistral version to install. Use latest `latest` to get automatic updates or pin it to numeric version like `2.1.1`.
 | `st2mistral_db`          | `mistral`     | PostgreSQL DB name for Mistral.
 | `st2mistral_db_username` | `mistral`     | PostgreSQL DB user for Mistral.
 | `st2mistral_db_password` | `StackStorm`  | PostgreSQL DB password for Mistral.
+| **epel**
+| `st2_proxies`             | `{}`         | Dictionary for http_proxy and https_proxy environment variables.
+| **mongodb**
+| `st2_proxies`             | `{}`         | Dictionary for http_proxy and https_proxy environment variables.
+| **nginx**
+| `st2_proxies`             | `{}`         | Dictionary for http_proxy and https_proxy environment variables.
+| **nginx**
+| `st2_proxies`             | `{}`         | Dictionary for http_proxy and https_proxy environment variables.
+| **postgresql**
+| `st2_proxies`             | `{}`         | Dictionary for http_proxy and https_proxy environment variables.
+
 
 ## Examples
 Install latest `stable` StackStorm with all its components on local machine:
@@ -60,6 +73,12 @@ This is default behavior. If you don't want updates - consider pinning version-r
 Install specific numeric version of st2 with pinned revision number as well:
 ```sh
 ansible-playbook stackstorm.yml --extra-vars='st2_version=2.1.1 st2_revision=8'
+```
+
+Use a proxy for fetching gpg keys:
+```sh
+ansible-playbook stackstorm.yml \
+    --extra-vars='{"st2_proxies": {"http_proxy": "http://localhost:3128", "https_proxy": http://localhost:3128"}}'
 ```
 
 ## Developing

--- a/roles/epel/defaults/main.yml
+++ b/roles/epel/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Empty proxies dictionary
+st2_proxies: {}

--- a/roles/epel/tasks/main.yml
+++ b/roles/epel/tasks/main.yml
@@ -13,3 +13,4 @@
     state: present
   when: ansible_os_family == "RedHat" and not epel_installed.stat.exists
   tags: epel
+  environment: "{{st2_proxies}}"

--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Empty proxies dictionary
+st2_proxies: {}

--- a/roles/mongodb/tasks/mongodb_apt.yaml
+++ b/roles/mongodb/tasks/mongodb_apt.yaml
@@ -6,6 +6,7 @@
     id: 42F3E95A2C4F08279C4960ADD68FA50FEA312927
     state: present
   tags: [databases, mongodb]
+  environment: "{{st2_proxies}}"
 
 - name: apt | Add mongodb repository
   become: yes

--- a/roles/mongodb/tasks/mongodb_yum.yaml
+++ b/roles/mongodb/tasks/mongodb_yum.yaml
@@ -7,6 +7,7 @@
     key: https://www.mongodb.org/static/pgp/server-3.2.asc
     state: present
   tags: [databases, mongodb]
+  environment: "{{st2_proxies}}"
 
 - name: yum | Add mongodb repository
   become: yes

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Empty proxies dictionary
+st2_proxies: {}

--- a/roles/nginx/tasks/nginx_apt.yml
+++ b/roles/nginx/tasks/nginx_apt.yml
@@ -6,6 +6,7 @@
     id: 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
     state: present
   tags: nginx
+  environment: "{{st2_proxies}}"
 
 - name: Add nginx repos
   become: yes

--- a/roles/nginx/tasks/nginx_yum.yml
+++ b/roles/nginx/tasks/nginx_yum.yml
@@ -5,6 +5,7 @@
     key: http://nginx.org/keys/nginx_signing.key
     state: present
   tags: nginx
+  environment: "{{st2_proxies}}"
 
 - name: Add nginx repos
   become: yes

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Empty proxies dictionary
+st2_proxies: {}

--- a/roles/postgresql/tasks/postgresql_yum6.yml
+++ b/roles/postgresql/tasks/postgresql_yum6.yml
@@ -6,6 +6,7 @@
     state: installed
   when: ansible_distribution == "CentOS"
   tags: [db, postgresql]
+  environment: "{{st2_proxies}}"
 
 - name: yum | Setup PostgreSQL repository for {{ ansible_distribution }}
   become: yes
@@ -14,6 +15,7 @@
     state: installed
   when: ansible_distribution == "RedHat"
   tags: [db, postgresql]
+  environment: "{{st2_proxies}}"
 
 - name: yum | Install PostgreSQL dependency
   become: yes

--- a/roles/st2/defaults/main.yml
+++ b/roles/st2/defaults/main.yml
@@ -21,3 +21,6 @@ st2_auth_username: testu
 st2_auth_password: testp
 # Save credentials in ~/.st2/config file
 st2_save_credentials: yes
+
+# Empty proxies dictionary
+st2_proxies: {}

--- a/roles/st2/tasks/main.yml
+++ b/roles/st2/tasks/main.yml
@@ -6,6 +6,7 @@
     state: present
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
   tags: st2
+  environment: "{{st2_proxies}}"
 
 - name: Install latest st2 package
   become: yes

--- a/roles/st2repos/defaults/main.yml
+++ b/roles/st2repos/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 # StackStorm PackageCloud repository to install: stable, unstable, staging-stable, staging-unstable.
 st2_pkg_repo: stable
+# Empty proxies dictionary
+st2_proxies: {}

--- a/roles/st2repos/tasks/st2repos_apt.yml
+++ b/roles/st2repos/tasks/st2repos_apt.yml
@@ -14,6 +14,7 @@
     id: 418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB
     url: https://packagecloud.io/StackStorm/{{ st2_pkg_repo }}/gpgkey
     state: present
+  environment: "{{st2_proxies}}"
 
 - name: Add StackStorm repo
   become: yes

--- a/roles/st2repos/tasks/st2repos_yum.yml
+++ b/roles/st2repos/tasks/st2repos_yum.yml
@@ -33,4 +33,5 @@
     gpgcheck: no
     enabled: yes
     sslverify: yes
+  environment: "{{st2_proxies}}"
   register: st2_repo_installed


### PR DESCRIPTION
This adds the option for setting proxy environment variables whenever an http or https operation is planned (apt-key, rpm -i <url>). 

Example of running (I setup squid on localhost):

    root@ansible-st2-ubuntu14:/vagrant# apt-key del D59097AB
    OK
    root@ansible-st2-ubuntu14:/vagrant# ansible-playbook stackstorm.yml --extra-vars='{"st2_proxies": {"http_proxy": "http://localhost:3128", "https_proxy": "http://localhost:3128"}}' -i 'localhost,' --connection=local
    
    TASK [st2repos : Add keys to keyring] ******************************************
    changed: [localhost]

    PLAY RECAP *********************************************************************
    localhost                  : ok=54   changed=1    unreachable=0    failed=0

From /var/log/squid3/access.log 

    1487778697.480      4 127.0.0.1 TCP_MISS/200 3358 CONNECT localhost:443 - HIER_DIRECT/127.0.0.1 -
    1487778803.128    389 127.0.0.1 TCP_MISS/200 6090 CONNECT packagecloud.io:443 - HIER_DIRECT/50.97.198.58 -
    1487778803.606    476 127.0.0.1 TCP_MISS/200 6638 CONNECT packagecloud.io:443 - HIER_DIRECT/50.97.198.58 -
    1487778804.007    392 127.0.0.1 TCP_MISS/200 6090 CONNECT packagecloud.io:443 - HIER_DIRECT/50.97.198.58 -
    1487778804.394    376 127.0.0.1 TCP_MISS/200 6090 CONNECT packagecloud.io:443 - HIER_DIRECT/50.97.198.58 -
    1487778804.867    472 127.0.0.1 TCP_MISS/200 10296 CONNECT packagecloud.io:443 - HIER_DIRECT/50.97.198.58 -
    1487778950.596    555 127.0.0.1 TCP_MISS/200 6090 CONNECT packagecloud.io:443 - HIER_DIRECT/50.97.198.58 -
    
And to just validate nothing is broken:

    root@ansible-st2-ubuntu14:/vagrant# apt-key del D59097AB
    OK
    root@ansible-st2-ubuntu14:/vagrant# ansible-playbook stackstorm.yml -i 'localhost,' --connection=local
    
    TASK [st2repos : Add keys to keyring] ******************************************
    changed: [localhost]
    PLAY RECAP *********************************************************************
    localhost                  : ok=54   changed=1    unreachable=0    failed=0
    