### PR TITLE
Fix temporary build failure due to bug in 'kitchen-ansible'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'test-kitchen'
-gem 'kitchen-ansible'
+gem 'kitchen-ansible', '0.46.0'
 gem 'kitchen-docker'
 gem 'kitchen-sync'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'test-kitchen'
+# TODO: Revert when https://github.com/neillturner/kitchen-ansible/issues/226#issuecomment-285985937 fixed
 gem 'kitchen-ansible', '0.46.0'
 gem 'kitchen-docker'
 gem 'kitchen-sync'


### PR DESCRIPTION
Temporary workaround to pin `kitchen-ansible` version, since recent `0.46.1` https://github.com/neillturner/kitchen-ansible/issues/226#issuecomment-285985937 broke second run of Ansible to test for idempotence.

Build error: https://travis-ci.org/StackStorm/ansible-st2/jobs/210297604

```
       bash: -c: line 3: syntax error near unexpected token `&&'
       bash: -c: line 3: ` && (echo 'Going to invoke ansible-playbook second time:';           '
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
```

TODO: Revert when the bug is fixed in upstream https://github.com/neillturner/kitchen-ansible/releases