### PR TITLE
Remove st2 service startup availability workaround

### DIFF
--- a/roles/st2smoketests/tasks/main.yml
+++ b/roles/st2smoketests/tasks/main.yml
@@ -25,15 +25,6 @@
   tags:
     - smoke-tests
 
-- name: Ensuring action runners are listening before proceeding
-  shell: cat /var/log/st2/st2actionrunner.*.log | grep amqp
-  register: output
-  until: output.stdout_lines|length > 1
-  retries: 5
-  changed_when: no
-  tags:
-    - smoke-tests
-
 - name: st2 run core.local -- date -R
   command: st2 run core.local -- date -R
   environment:


### PR DESCRIPTION
This part of a bigger cleanup, removes some dirty hacks we introduced before.

See: https://github.com/StackStorm/st2-packages/issues/429 for more info about improvement in StackStorm services which now should handle readiness/availability natively.

----

`ansible-st2` CI is expected to fail until https://github.com/StackStorm/st2-packages/pull/435 fix will propagate across both `unstable` and `stable` StackStorm repos.
Once the full transition is finished, - we can merge this PR.