### PR TITLE
st2_api_key  generation now part of "st2chatops"role and "st2 pack install st2" in smoketests/main.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ Below is the list of variables you can redefine in your playbook to customize st
 | `st2mistral_db_username` | `mistral`     | PostgreSQL DB user for Mistral.
 | `st2mistral_db_password` | `StackStorm`  | PostgreSQL DB password for Mistral.
 | **bwc**
-| `bwc_license`            | `null`        | BWC license key is required for installing BWC enteprise bits via this ansible role. 
+| `bwc_license`            | `null`        | BWC license key is required for installing BWC enteprise bits via this ansible role.
 | `bwc_pkg_repo`           | `enterprise`  | BWC PackageCloud repository to install. [`enterprise`](https://packagecloud.io/StackStorm/enterprise/), [`enterprise-unstable`](https://packagecloud.io/StackStorm/enterprise-unstable/), [`staging-enterprise`](https://packagecloud.io/StackStorm/staging-enteprise/), [`staging-enterprise-unstable`](https://packagecloud.io/StackStorm/staging-enterprise-unstable/)
-| `bwc_version`            | `latest`      | BWC enterprise version to install. Use latest `latest` to get automatic updates or pin it to numeric version like `2.1.1`. The version used here should match `st2_version`. 
+| `bwc_version`            | `latest`      | BWC enterprise version to install. Use latest `latest` to get automatic updates or pin it to numeric version like `2.2.0`. The version used here should match `st2_version`.
 | `bwc_revision`           | `1`           | BWC enterprise revision to install. Used only with pinned `bwc_version`.
 | `bwc_rbac` | [See `bwc_rbac` variable in role defaults](roles/bwc/defaults/main.yml) | BWC RBAC roles and assignments. This is a dictionary with two keys `roles` and `assignments`. `roles` and `assignments` are in turn both arrays. Each element in the array follows the exact YAML schema for [roles](https://bwc-docs.brocade.com/rbac.html#user-permissions) and [assignments](https://bwc-docs.brocade.com/rbac.html#defining-user-role-assignments) defined in BWC documentation.
 | `bwc_ldap` | [See `bwc_ldap` variable in role defaults](roles/bwc/defaults/main.yml) | Settings for BWC LDAP authentication backend. `bwc_ldap` is a dictionary and has one item `backend_kwargs`. `backend_kwargs` should be provided as exactly listed in BWC documentation for [LDAP configuration](https://bwc-docs.brocade.com/authentication.html#auth-backends).
 | **st2chatops**
-| `st2chatops_st2_api_key` |               | st2 API key to be updated in st2chatops.env using "st2 apikey create -k" in a task [**Required**]
+| `st2chatops_st2_api_key` |               | st2 API key to be updated in st2chatops.env using "st2 apikey create -k" in a task
 | `st2chatops_hubot_adapter` |             | Hubot Adapter to be used for st2chatops. Default is `shell`, but should be changed to one of the [`supported adapters`](`https://github.com/StackStorm/ansible-st2/blob/master/roles/st2chatops/vars/main.yml`).[**Required**]
 | `st2chatops_config`      | `{ }`         | Based on adapter in `st2chatops_hubot_adapter`, provide hash for the adapter settings, to update [`st2chatops.env`](https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env). For example, for `Slack` hubot adapter: `st2chatops_config: {"HUBOT_SLACK_TOKEN": "xoxb-CHANGE-ME-PLEASE"}`
 | `st2chatops_version`     | `latest`      | st2chatops version to install. Use `latest` to get automatic updates or pin it to numeric version like `2.2.0`.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Below is the list of variables you can redefine in your playbook to customize st
 | **st2chatops**
 | `st2chatops_st2_api_key` |               | st2 API key to be updated in st2chatops.env using "st2 apikey create -k" in a task
 | `st2chatops_hubot_adapter` |             | Hubot Adapter to be used for st2chatops. Default is `shell`, but should be changed to one of the [`supported adapters`](`https://github.com/StackStorm/ansible-st2/blob/master/roles/st2chatops/vars/main.yml`).[**Required**]
-| `st2chatops_config`      | `{ }`         | Based on adapter in `st2chatops_hubot_adapter`, provide hash for the adapter settings, to update [`st2chatops.env`](https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env). For example, for `Slack` hubot adapter: `st2chatops_config:``HUBOT_SLACK_TOKEN: xoxb-CHANGE-ME-PLEASE`
+| `st2chatops_config`      | `{ }`         | Based on adapter in `st2chatops_hubot_adapter`, provide hash for the adapter settings, to update [`st2chatops.env`](https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env). For example, for `Slack` hubot adapter: `st2chatops_config:` `HUBOT_SLACK_TOKEN: xoxb-CHANGE-ME-PLEASE`
 | `st2chatops_version`     | `latest`      | st2chatops version to install. Use `latest` to get automatic updates or pin it to numeric version like `2.2.0`.
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Below is the list of variables you can redefine in your playbook to customize st
 | **st2chatops**
 | `st2chatops_st2_api_key` |               | st2 API key to be updated in st2chatops.env using "st2 apikey create -k" in a task
 | `st2chatops_hubot_adapter` |             | Hubot Adapter to be used for st2chatops. Default is `shell`, but should be changed to one of the [`supported adapters`](`https://github.com/StackStorm/ansible-st2/blob/master/roles/st2chatops/vars/main.yml`).[**Required**]
-| `st2chatops_config`      | `{ }`         | Based on adapter in `st2chatops_hubot_adapter`, provide hash for the adapter settings, to update [`st2chatops.env`](https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env). For example, for `Slack` hubot adapter: `st2chatops_config: {"HUBOT_SLACK_TOKEN": "xoxb-CHANGE-ME-PLEASE"}`
+| `st2chatops_config`      | `{ }`         | Based on adapter in `st2chatops_hubot_adapter`, provide hash for the adapter settings, to update [`st2chatops.env`](https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env). For example, for `Slack` hubot adapter: `st2chatops_config:``HUBOT_SLACK_TOKEN: xoxb-CHANGE-ME-PLEASE`
 | `st2chatops_version`     | `latest`      | st2chatops version to install. Use `latest` to get automatic updates or pin it to numeric version like `2.2.0`.
 
 ## Examples

--- a/roles/st2chatops/tasks/main.yml
+++ b/roles/st2chatops/tasks/main.yml
@@ -5,11 +5,13 @@
       '"st2chatops_hubot_adapter" must be one of the supported adapters in
       https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env'
   when: st2chatops_hubot_adapter not in supported_hubot_adapters
+  tags: st2chatops
 
 - name: Assert st2chatops_hubot_adapter "{{ st2chatops_hubot_adapter|upper }}" settings are specified
   fail:
     msg: '"st2chatops_config" hash cannot be empty for "{{ st2chatops_hubot_adapter|upper }}" hubot adapter.'
   when: st2chatops_config.keys() == [] and st2chatops_hubot_adapter != "shell"
+  tags: st2chatops
 
 - name: Install latest st2chatops package
   become: yes
@@ -29,10 +31,11 @@
 
 - name: Check if api key already exist. No change if it already exists
   become: yes
-  shell: "grep -e '^export ST2_API_KEY=\"\\${ST2_API_KEY}\"$' /opt/stackstorm/chatops/st2chatops.env"
+  command: "grep -e '^export ST2_API_KEY=\"\\${ST2_API_KEY}\"$' /opt/stackstorm/chatops/st2chatops.env"
   changed_when: no
   ignore_errors: True
   register: task_apikey_exists
+  tags: st2chatops
 
 - name: Add user defined "st2chatops_st2_api_key" in st2chatops.env, from "role" or "defaults/main.yml"
   become: yes
@@ -90,16 +93,18 @@
   tags: [st2chatops, skip_ansible_lint]
 
 - name: Check if any adapter is enabled
-  shell: "grep -e '^export HUBOT_ADAPTER=' /opt/stackstorm/chatops/st2chatops.env"
+  command: "grep -e '^export HUBOT_ADAPTER=' /opt/stackstorm/chatops/st2chatops.env"
   ignore_errors: True
   register: task_adapter_enabled
   changed_when: False
+  tags: st2chatops
 
 - name: Set variable enabled_adapter
   set_fact:
     enabled_adapter: '{% set list_var = (task_adapter_enabled.stdout).split("=") %}{{ list_var[1] }}'
   ignore_errors: True
   changed_when: False
+  tags: st2chatops
 
 - name: Comment existing hubot adapters in "/opt/stackstorm/chatops/st2chatops.env"
   become: yes

--- a/roles/st2chatops/tasks/main.yml
+++ b/roles/st2chatops/tasks/main.yml
@@ -10,7 +10,9 @@
 - name: Assert st2chatops_hubot_adapter "{{ st2chatops_hubot_adapter|upper }}" settings are specified
   fail:
     msg: '"st2chatops_config" hash cannot be empty for "{{ st2chatops_hubot_adapter|upper }}" hubot adapter.'
-  when: st2chatops_config.keys() == [] and st2chatops_hubot_adapter != "shell"
+  when: >
+    (st2chatops_config == None) or
+    (st2chatops_config == {} and st2chatops_hubot_adapter != "shell")
   tags: st2chatops
 
 - name: Install latest st2chatops package
@@ -33,7 +35,7 @@
   become: yes
   command: "grep -e '^export ST2_API_KEY=\"\\${ST2_API_KEY}\"$' /opt/stackstorm/chatops/st2chatops.env"
   changed_when: no
-  ignore_errors: True
+  ignore_errors: true
   register: task_apikey_exists
   tags: st2chatops
 
@@ -54,7 +56,9 @@
 
 - name: Generate authentication token
   command: st2 auth {{ st2_auth_username }} -p {{ st2_auth_password }} -t
-  when: (task_apikey_exists.failed is not defined) and (task_user_st2_api_key.changed == false)
+  when: >
+    (task_apikey_exists.failed is not defined) and
+    (task_user_st2_api_key.changed == false)
   register: task_st2_token
   tags: [st2chatops, skip_ansible_lint]
 
@@ -94,16 +98,16 @@
 
 - name: Check if any adapter is enabled
   command: "grep -e '^export HUBOT_ADAPTER=' /opt/stackstorm/chatops/st2chatops.env"
-  ignore_errors: True
+  ignore_errors: true
   register: task_adapter_enabled
-  changed_when: False
+  changed_when: no
   tags: st2chatops
 
 - name: Set variable enabled_adapter
   set_fact:
     enabled_adapter: '{% set list_var = (task_adapter_enabled.stdout).split("=") %}{{ list_var[1] }}'
-  ignore_errors: True
-  changed_when: False
+  ignore_errors: true
+  changed_when: no
   tags: st2chatops
 
 - name: Comment existing hubot adapters in "/opt/stackstorm/chatops/st2chatops.env"
@@ -112,8 +116,9 @@
     dest: /opt/stackstorm/chatops/st2chatops.env
     regexp: '^(export HUBOT_ADAPTER=.*)'
     replace: '# \1'
-  when: 'enabled_adapter != "{{ st2chatops_hubot_adapter }}" or enabled_adapter is not defined'
-  changed_when: no
+  when: >
+    (enabled_adapter != "{{ st2chatops_hubot_adapter }}") or
+    (enabled_adapter is not defined)
   tags: st2chatops
 
 - name: Uncomment Hubot "{{ st2chatops_hubot_adapter|upper }}" adapter in "/opt/stackstorm/chatops/st2chatops.env"

--- a/roles/st2chatops/tasks/main.yml
+++ b/roles/st2chatops/tasks/main.yml
@@ -2,7 +2,8 @@
 - name: Assert st2chatops_hubot_adapter is specified
   fail:
     msg: >
-      '"st2chatops_hubot_adapter" must be one of the supported adapters in https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env'
+      '"st2chatops_hubot_adapter" must be one of the supported adapters in
+      https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env'
   when: st2chatops_hubot_adapter not in supported_hubot_adapters
 
 - name: Assert st2chatops_hubot_adapter "{{ st2chatops_hubot_adapter|upper }}" settings are specified
@@ -26,32 +27,54 @@
   when: st2chatops_version != "latest"
   tags: [st2chatops, skip_ansible_lint]
 
-- name: Get authentication token
-  command: st2 auth {{ st2_auth_username }} -p {{ st2_auth_password }} -t
-  register: st2_token
+- name: Check if api key already exist. No change if it already exists
+  become: yes
+  shell: "cat /opt/stackstorm/chatops/st2chatops.env | grep -e '^export ST2_API_KEY=\"\\${ST2_API_KEY}\"$'"
   changed_when: no
-  tags: st2chatops
+  ignore_errors: True
+  register: task_apikey_exists
 
-- name: Generate st2api key
-  command: st2 apikey create -k
-  environment:
-    ST2_AUTH_TOKEN: "{{ st2_token.stdout }}"
-  register: st2chatops_st2_api_key
-  changed_when: no
-  no_log: true
-  tags: st2chatops
-
-- name: Add st2_api_key in st2chatops.env
+- name: Add user defined "st2chatops_st2_api_key" in st2chatops.env, from "role" or "defaults/main.yml"
   become: yes
   replace:
     dest: /opt/stackstorm/chatops/st2chatops.env
     regexp: '(?<=ST2_API_KEY=)(\"\$\{ST2_API_KEY\}\")$'
-    replace: '{{ st2chatops_st2_api_key.stdout }}'
-  when: st2chatops_st2_api_key != 'CHANGE-ME-PLEASE'
-  register: task_st2_api_key
+    replace: '{{ st2chatops_st2_api_key }}'
+  when: >
+    (task_apikey_exists.failed is not defined) and
+    (st2chatops_st2_api_key is defined) and
+    (st2chatops_st2_api_key != "CHANGE-ME-PLEASE")
+  register: task_user_st2_api_key
   no_log: true
   notify: restart st2chatops
   tags: st2chatops
+
+- name: Generate authentication token
+  command: st2 auth {{ st2_auth_username }} -p {{ st2_auth_password }} -t
+  when: (task_apikey_exists.failed is not defined) and (task_user_st2_api_key.changed == false)
+  register: task_st2_token
+  tags: [st2chatops, skip_ansible_lint]
+
+- name: Generate "st2_api_key" if not provided with the "role" or in "defaults/main.yml"
+  command: st2 apikey create -k
+  environment:
+    ST2_AUTH_TOKEN: "{{ task_st2_token.stdout }}"
+  when: task_st2_token.changed
+  register: task_generated_api_key
+  no_log: true
+  tags: [st2chatops, skip_ansible_lint]
+
+- name: Add generated "st2_api_key" in st2chatops.env
+  become: yes
+  replace:
+    dest: /opt/stackstorm/chatops/st2chatops.env
+    regexp: '(?<=ST2_API_KEY=)(\"\$\{ST2_API_KEY\}\")$'
+    replace: '{{ task_generated_api_key.stdout }}'
+  when: task_generated_api_key.changed
+  register: task_st2_api_key
+  no_log: true
+  notify: restart st2chatops
+  tags: [st2chatops, skip_ansible_lint]
 
 - name: Comment Username, Password and Auth URL, if API_KEY provided
   become: yes
@@ -63,7 +86,7 @@
     - '^(export ST2_AUTH_URL.*)'
     - '^(export ST2_AUTH_USERNAME.*)'
     - '^(export ST2_AUTH_PASSWORD.*)'
-  when: task_st2_api_key.changed
+  when: (task_st2_api_key.changed) or (task_user_st2_api_key.changed)
   tags: [st2chatops, skip_ansible_lint]
 
 - name: Check if any adapter is enabled

--- a/roles/st2chatops/tasks/main.yml
+++ b/roles/st2chatops/tasks/main.yml
@@ -29,7 +29,7 @@
 
 - name: Check if api key already exist. No change if it already exists
   become: yes
-  shell: "cat /opt/stackstorm/chatops/st2chatops.env | grep -e '^export ST2_API_KEY=\"\\${ST2_API_KEY}\"$'"
+  shell: "grep -e '^export ST2_API_KEY=\"\\${ST2_API_KEY}\"$' /opt/stackstorm/chatops/st2chatops.env"
   changed_when: no
   ignore_errors: True
   register: task_apikey_exists
@@ -90,7 +90,7 @@
   tags: [st2chatops, skip_ansible_lint]
 
 - name: Check if any adapter is enabled
-  shell: "cat /opt/stackstorm/chatops/st2chatops.env | grep -e '^export HUBOT_ADAPTER=' "
+  shell: "grep -e '^export HUBOT_ADAPTER=' /opt/stackstorm/chatops/st2chatops.env"
   ignore_errors: True
   register: task_adapter_enabled
   changed_when: False

--- a/roles/st2chatops/tasks/main.yml
+++ b/roles/st2chatops/tasks/main.yml
@@ -26,12 +26,27 @@
   when: st2chatops_version != "latest"
   tags: [st2chatops, skip_ansible_lint]
 
+- name: Get authentication token
+  command: st2 auth {{ st2_auth_username }} -p {{ st2_auth_password }} -t
+  register: st2_token
+  changed_when: no
+  tags: st2chatops
+
+- name: Generate st2api key
+  command: st2 apikey create -k
+  environment:
+    ST2_AUTH_TOKEN: "{{ st2_token.stdout }}"
+  register: st2chatops_st2_api_key
+  changed_when: no
+  no_log: true
+  tags: st2chatops
+
 - name: Add st2_api_key in st2chatops.env
   become: yes
   replace:
     dest: /opt/stackstorm/chatops/st2chatops.env
-    regexp: '(?<=ST2_API_KEY=)(.*)$'
-    replace: '{{ st2chatops_st2_api_key }}'
+    regexp: '(?<=ST2_API_KEY=)(\"\$\{ST2_API_KEY\}\")$'
+    replace: '{{ st2chatops_st2_api_key.stdout }}'
   when: st2chatops_st2_api_key != 'CHANGE-ME-PLEASE'
   register: task_st2_api_key
   no_log: true

--- a/roles/st2smoketests/tasks/main.yml
+++ b/roles/st2smoketests/tasks/main.yml
@@ -50,40 +50,6 @@
   tags:
     - smoke-tests
 
-- name: Generate st2api key
-  command: st2 apikey create -k
-  environment:
-    ST2_AUTH_TOKEN: "{{ st2_token.stdout }}"
-  register: st2_api_key
-  changed_when: no
-  no_log: true
-  tags:
-    - smoke-tests
-
-- name: Update st2_api_key in st2chatops.env
-  become: yes
-  replace:
-    dest: /opt/stackstorm/chatops/st2chatops.env
-    regexp: '(?<=ST2_API_KEY=)(.*)$'
-    replace: '{{ st2_api_key.stdout }}'
-  no_log: true
-  changed_when: no
-  tags:
-    - smoke-tests
-
-- name: Comment Username, Password and Auth URL, if API_KEY provided
-  become: yes
-  replace:
-    dest: /opt/stackstorm/chatops/st2chatops.env
-    regexp: '{{ item }}'
-    replace: '# \1'
-  with_items:
-    - '^(export ST2_AUTH_URL.*)'
-    - '^(export ST2_AUTH_USERNAME.*)'
-    - '^(export ST2_AUTH_PASSWORD.*)'
-  tags:
-    - smoke-tests
-
 - name: Install st2 pack from exchange
   become: yes
   environment:

--- a/roles/st2smoketests/tasks/main.yml
+++ b/roles/st2smoketests/tasks/main.yml
@@ -60,11 +60,42 @@
   tags:
     - smoke-tests
 
+- name: Update st2_api_key in st2chatops.env
+  become: yes
+  replace:
+    dest: /opt/stackstorm/chatops/st2chatops.env
+    regexp: '(?<=ST2_API_KEY=)(.*)$'
+    replace: '{{ st2_api_key.stdout }}'
+  no_log: true
+  changed_when: no
+  tags:
+    - smoke-tests
+
+- name: Comment Username, Password and Auth URL, if API_KEY provided
+  become: yes
+  replace:
+    dest: /opt/stackstorm/chatops/st2chatops.env
+    regexp: '{{ item }}'
+    replace: '# \1'
+  with_items:
+    - '^(export ST2_AUTH_URL.*)'
+    - '^(export ST2_AUTH_USERNAME.*)'
+    - '^(export ST2_AUTH_PASSWORD.*)'
+  tags:
+    - smoke-tests
+
+- name: Install st2 pack from exchange
+  become: yes
+  environment:
+    ST2_AUTH_TOKEN: "{{ st2_token.stdout }}"
+  command: "st2 pack install st2"
+  changed_when: no
+  tags:
+    - smoke-tests
+
 - name: st2chatops smoketests for "SLACK"
   include: >
     st2chatops_smoketests.yml
-    ST2_AUTH_TOKEN={{ st2_token.stdout }}
-    st2chatops_api_key={{ st2_api_key.stdout  }}
     st2chatops_hubot_adapter=slack
     st2chatops_config={'HUBOT_SLACK_TOKEN':'{{ hubot_token }}'}
   when: hubot_token is defined

--- a/roles/st2smoketests/tasks/st2chatops_smoketests.yml
+++ b/roles/st2smoketests/tasks/st2chatops_smoketests.yml
@@ -52,7 +52,29 @@
   args:
     chdir: "/opt/stackstorm/chatops/"
   register: test_output
-  failed_when: "'{{ st2chatops_hubot_adapter|title }} client now connected' not in test_output.stdout or 'DEBUG Added command: st2 list' not in test_output.stdout"
+  failed_when: >
+    "'{{ st2chatops_hubot_adapter|title }} client now connected' not in test_output.stdout or
+    'DEBUG Added command: st2 list' not in test_output.stdout"
+  changed_when: no
+  tags:
+    - smoke-tests
+
+- name: TEARDOWN Comment "SLACK" hubot adapters in "st2chatops.env"
+  become: yes
+  replace:
+    dest: /opt/stackstorm/chatops/st2chatops.env
+    regexp: '^(export HUBOT_ADAPTER=slack)'
+    replace: '# \1'
+  changed_when: no
+  tags:
+    - smoke-tests
+
+- name: TEARDOWN Uncomment "SHELL" adapter
+  become: yes
+  replace:
+    dest: /opt/stackstorm/chatops/st2chatops.env
+    regexp: '^# (export HUBOT_ADAPTER=shell)$'
+    replace: '\1'
   changed_when: no
   tags:
     - smoke-tests

--- a/roles/st2smoketests/tasks/st2chatops_smoketests.yml
+++ b/roles/st2smoketests/tasks/st2chatops_smoketests.yml
@@ -1,43 +1,9 @@
 - name: Set variables and hubot adapter settings
   set_fact:
-    st2chatops_api_key: "{{ st2chatops_api_key  }}"
     st2chatops_hubot_adapter: "{{ st2chatops_hubot_adapter }}"
     st2chatops_config: "{{ st2chatops_config }}"
   changed_when: no
   no_log: true
-  tags:
-    - smoke-tests
-
-- name: Install st2 pack from exchange
-  become: yes
-  environment:
-    ST2_AUTH_TOKEN: "{{ ST2_AUTH_TOKEN }}"
-  command: "st2 pack install st2"
-  changed_when: no
-  tags:
-    - smoke-tests
-
-- name: Update st2_api_key in st2chatops.env
-  become: yes
-  replace:
-    dest: /opt/stackstorm/chatops/st2chatops.env
-    regexp: '(?<=ST2_API_KEY=)(.*)$'
-    replace: '{{ st2chatops_api_key }}'
-  no_log: true
-  changed_when: no
-  tags:
-    - smoke-tests
-
-- name: Comment Username, Password and Auth URL, if API_KEY provided
-  become: yes
-  replace:
-    dest: /opt/stackstorm/chatops/st2chatops.env
-    regexp: '{{ item }}'
-    replace: '# \1'
-  with_items:
-    - '^(export ST2_AUTH_URL.*)'
-    - '^(export ST2_AUTH_USERNAME.*)'
-    - '^(export ST2_AUTH_PASSWORD.*)'
   tags:
     - smoke-tests
 

--- a/roles/st2smoketests/tasks/st2chatops_smoketests.yml
+++ b/roles/st2smoketests/tasks/st2chatops_smoketests.yml
@@ -52,9 +52,7 @@
   args:
     chdir: "/opt/stackstorm/chatops/"
   register: test_output
-  failed_when: >
-    "'{{ st2chatops_hubot_adapter|title }} client now connected' not in test_output.stdout or
-    'DEBUG Added command: st2 list' not in test_output.stdout"
+  failed_when: "'{{ st2chatops_hubot_adapter|title }} client now connected' not in test_output.stdout or 'DEBUG Added command: st2 list' not in test_output.stdout"
   changed_when: no
   tags:
     - smoke-tests


### PR DESCRIPTION
- [x] Move `st2 pack install st2` in `smoketests/main.yaml` as a test, from `st2chatops_smoketests.yml`

- [x] Make API key generation robust. 

Sample st2chatops role in a playbook:
```
- name: Install StackStorm with all services on a single node
  hosts: localhost
  roles:
    - (......other roles......)
    - name: Install st2chatops with "slack" hubot adapter
      role: st2chatops
      vars:
        st2chatops_hubot_adapter: slack
        st2chatops_config: {"HUBOT_SLACK_TOKEN":"xoxb-CHANGE-ME-PLEASE"}
        # optional
        st2chatops_version: latest
        st2chatops_st2_api_key: CHANGE-ME-PLEASE 
        # This can be generated using "st2 apikey create -k" in a pre_task or updated in defaults/main.yml.
        # If not provided will it will be generated in the role, if not already updated.
```