### PR TITLE
Revert "Fix temporary build failure due to bug in 'kitchen-ansible'"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'test-kitchen'
-# TODO: Revert when https://github.com/neillturner/kitchen-ansible/issues/226#issuecomment-285985937 fixed
-gem 'kitchen-ansible', '0.46.0'
+gem 'kitchen-ansible'
 gem 'kitchen-docker'
 gem 'kitchen-sync'


### PR DESCRIPTION
Reverts StackStorm/ansible-st2#127 since `kitchen-ansible` is fixed in recent versions.