### PR TITLE
 Make Ubuntu16 default box for Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ st2smoketests, you will need to disable proxy for localhost.
 ```
 
 ## Developing
-
-There are a few requirements when developing on `ansible-st2`:
+There are a few requirements when developing on `ansible-st2`.
 
 These are the platforms we must support (must pass end-to-end testing):
 - Xenial
@@ -99,6 +98,18 @@ These are the platforms we must support (must pass end-to-end testing):
 - RHEL7 (via AWS)
 
 Must also support Ansible Idempotence (Eg. Ansible-playbook re-run should end with the following results: `changed=0.*failed=0`)
+
+For development purposes there is [Vagrantfile](Vagrantfile) available. The following command will setup ubuntu16 box (`ubuntu/xenial64`) by default:
+```sh
+vagrant up
+```
+
+Other distros:
+```sh
+vagrant up ubuntu14
+vagrant up centos6
+vagrant up centos7
+```
 
 ## Other Installers
 You might be interested in other methods to deploy StackStorm engine:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Aka IFTTT orchestration for Ops.
 * RHEL6 / CentOS6
 * RHEL7 / CentOS7
 
-> If you're using the provided Vagrantfile, note that it uses Xenial by default. Due to some of the changes there, Vagrant 1.9.1 or better is required.
+> If you're using the provided Vagrantfile, note that it uses Xenial by default.
 
 ## Requirements
 At least 2GB of memory and 3.5GB of disk space is required, since StackStorm is shipped with RabbitMQ, PostgreSQL, Mongo, nginx and OpenStack Mistral.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.forward_agent = true
 
   VIRTUAL_MACHINES.each do |name, cfg|
-    config.vm.define name do |vm_config|
+    config.vm.define name, autostart: (name == :ubuntu16) do |vm_config|
       vm_config.vm.hostname = cfg[:hostname]
       vm_config.vm.box = cfg[:box]
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-VAGRANTFILE_API_VERSION = '2'
 VIRTUAL_MACHINES = {
   :ubuntu14 => {
     :hostname => 'ansible-st2-ubuntu14',
@@ -21,8 +20,8 @@ VIRTUAL_MACHINES = {
   },
 }
 
-
-Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+Vagrant.require_version ">= 1.9.1"
+Vagrant.configure(2) do |config|
   config.vm.network "forwarded_port", guest: 22, host: 2200, auto_correct: true
   config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
   config.ssh.forward_agent = true


### PR DESCRIPTION
With this small change `vagrant up` will setup only `ubuntu16` VM, instead of bringing up entire fleet of 4 machines.