### PR TITLE
Add an option to configure custom SSL certificate for st2web/nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Below is the list of variables you can redefine in your playbook to customize st
 | `st2mistral_db`          | `mistral`     | PostgreSQL DB name for Mistral.
 | `st2mistral_db_username` | `mistral`     | PostgreSQL DB user for Mistral.
 | `st2mistral_db_password` | `StackStorm`  | PostgreSQL DB password for Mistral.
+| **st2web**
+| `st2web_ssl_certificate`     | `null` | String with custom SSL certificate (`.crt`). If not provided, self-signed certificate will be generated.
+| `st2web_ssl_certificate_key` | `null` | String with custom SSL certificate secret key (`.key`). If not provided, self-signed certificate will be generated.
 | **bwc**
 | `bwc_license`            | `null`        | BWC license key is required for installing BWC enteprise bits via this ansible role.
 | `bwc_pkg_repo`           | `enterprise`  | BWC PackageCloud repository to install. [`enterprise`](https://packagecloud.io/StackStorm/enterprise/), [`enterprise-unstable`](https://packagecloud.io/StackStorm/enterprise-unstable/), [`staging-enterprise`](https://packagecloud.io/StackStorm/staging-enteprise/), [`staging-enterprise-unstable`](https://packagecloud.io/StackStorm/staging-enterprise-unstable/)

--- a/roles/st2web/defaults/main.yml
+++ b/roles/st2web/defaults/main.yml
@@ -1,3 +1,9 @@
 ---
 # defaults file for st2web
 st2web_revision: 1
+
+# String with custom SSL certificate. If not provided, self-signed certificate will be generated.
+st2web_ssl_certificate: null
+
+# String with custom SSL certificate private key. If not provided, self-signed certificate will be generated.
+st2web_ssl_certificate_key: null

--- a/roles/st2web/tasks/certificate.yml
+++ b/roles/st2web/tasks/certificate.yml
@@ -1,0 +1,37 @@
+---
+- name: Verify if custom SSL certificate was correctly specified
+  fail:
+    msg: "When using custom certificate, both 'st2web_ssl_certificate' and 'st2web_ssl_certificate_key' must be provided"
+  # no XOR in Yaml
+  when: (st2web_ssl_certificate and not st2web_ssl_certificate_key) or (not st2web_ssl_certificate and st2web_ssl_certificate_key)
+
+- name: Create SSL certificate directory
+  become: yes
+  file:
+    state: directory
+    dest: /etc/ssl/st2
+    mode: 0700
+
+- name: Save custom SSL certificate
+  become: yes
+  copy:
+    content: "{{ item.cert }}"
+    dest: "{{ item.path }}"
+    mode: 0600
+  with_items:
+    - cert: "{{ st2web_ssl_certificate }}"
+      path: /etc/ssl/st2/st2.crt
+    - cert: "{{ st2web_ssl_certificate_key }}"
+      path: /etc/ssl/st2/st2.key
+  notify:
+    - restart nginx
+  when: st2web_ssl_certificate and st2web_ssl_certificate_key
+
+- name: Generate self-signed SSL certificate
+  become: yes
+  shell: openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt -days 365 -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information Technology/CN=$(hostname)"
+  args:
+    creates: /etc/ssl/st2/st2.key
+  notify:
+    - restart nginx
+  when: not st2web_ssl_certificate and not st2web_ssl_certificate_key

--- a/roles/st2web/tasks/certificate.yml
+++ b/roles/st2web/tasks/certificate.yml
@@ -11,6 +11,8 @@
     state: directory
     dest: /etc/ssl/st2
     mode: 0700
+    owner: root
+    group: root
 
 - name: Save custom SSL certificate
   become: yes
@@ -18,6 +20,8 @@
     content: "{{ item.cert }}"
     dest: "{{ item.path }}"
     mode: 0600
+    owner: root
+    group: root
   with_items:
     - cert: "{{ st2web_ssl_certificate }}"
       path: /etc/ssl/st2/st2.crt

--- a/roles/st2web/tasks/main.yml
+++ b/roles/st2web/tasks/main.yml
@@ -27,21 +27,9 @@
   when: st2_version != "latest"
   tags: st2web
 
-- name: Create ssl cert dir
-  become: yes
-  file:
-    state: directory
-    dest: /etc/ssl/st2
-  tags: st2web
-
-- name: Create ssl cert
-  become: yes
-  shell: openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt -days 365 -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information Technology/CN=$(hostname)"
-  args:
-    creates: /etc/ssl/st2/st2.key
-  notify:
-    - restart nginx
-  tags: st2web
+- name: Configure SSL certificate for st2web UI
+  include: certificate.yml
+  tags: st2web, certificate
 
 - name: Copy Nginx config
   become: yes


### PR DESCRIPTION
Closes #132 

Add 2 new vars for `st2web` role: `st2web_ssl_certificate` and `st2web_ssl_certificate_key`.
If both vars are provided, - save the cert. If not provided, - generate self-signed certificate as it was before.

The default behavior remains as before: generting self-signed cert for `st2web` UI,

### Example usage
```yaml
- name: Install StackStorm
  hosts: all
  roles:
    ...
    - name: Install st2web
      role: st2web
      vars:
        st2web_ssl_certificate: "{{ lookup('file', 'local/path/to/domain-name.crt') }}"
        st2web_ssl_certificate_key: "{{ lookup('file', 'local/path/to/domain-name.key') }}"
```


### TODO
- [ ] Verify for real with a custom cert
