### PR TITLE
Fix to make it possible to read file on a remote node

### DIFF
--- a/roles/bwc/tasks/bwc_repos_setup.yml
+++ b/roles/bwc/tasks/bwc_repos_setup.yml
@@ -32,11 +32,17 @@
       Content-Type: "application/x-www-form-urlencoded"
     body: "name={{ ansible_nodename }}"
 
-- name: Set bwc_read_token variable
+- name: Read bwc_read_token from file
   become: yes
   no_log: yes
+  changed_when: no
+  command: cat "/etc/packagecloud/StackStorm_{{ bwc_repo }}_read_token.txt"
+  register: _bwc_read_token
+
+- name: Set bwc_read_token variable
+  no_log: yes
   set_fact:
-    bwc_read_token: "{{ lookup('file', '/etc/packagecloud/StackStorm_{{ bwc_repo }}_read_token.txt') }}"
+    bwc_read_token: "{{ _bwc_read_token.stdout }}"
 
 - name: Add BWC enterprise repos on {{ ansible_distribution }}
   include: bwc_repos_{{ ansible_pkg_mgr }}.yml

--- a/roles/bwc/tasks/license.yml
+++ b/roles/bwc/tasks/license.yml
@@ -5,9 +5,16 @@
     path: /etc/packagecloud/bwc_license_hash.txt
   register: bwc_license_hash_file
 
-- name: Read bwc_license_hash from file if it exits
+- name: Read bwc_license_hash_file if it exits
+  command: cat /etc/packagecloud/bwc_license_hash.txt
+  register: _bwc_license_hash
+  no_log: yes
+  changed_when: no
+  when: bwc_license_hash_file.stat.exists
+
+- name: Set bwc_license_hash from file context
   set_fact:
-    bwc_license_hash: "{{ lookup('file', '/etc/packagecloud/bwc_license_hash.txt') }}"
+    bwc_license_hash: "{{ _bwc_license_hash.stdout }}"
   no_log: yes
   when: bwc_license_hash_file.stat.exists
 

--- a/roles/st2smoketests/tasks/st2chatops_smoketests.yml
+++ b/roles/st2smoketests/tasks/st2chatops_smoketests.yml
@@ -48,7 +48,7 @@
     - smoke-tests
 
 - name: Verify st2chatops using bin/hubot
-  command: "timeout 10 bin/hubot"
+  command: "timeout 25 bin/hubot"
   args:
     chdir: "/opt/stackstorm/chatops/"
   register: test_output


### PR DESCRIPTION
When I execute stackstorm.yml playbook to build StackStorm environment from another (management) node, the following task is failed.
```
TASK [bwc : Read bwc_license_hash from file if it exits] ***********************
 [WARNING]: Unable to find '/etc/packagecloud/bwc_license_hash.txt' in expected paths.

fatal: [192.168.100.14]: FAILED! => {"failed": true, "msg": "An unhandled exception occurred while running the lookup plugin 'file'. Error was a <class 'ansible.errors.AnsibleError'>, original message: could not locate file in lookup: /etc/packagecloud/bwc_license_hash.txt"}
        to retry, use: --limit @/home/ubuntu/ansible-st2/stackstorm.retry
```

The task of `Read bwc_license_hash from file if it exits` failed to read the `bwc_license_hash_file`. Because the `when` statement checks a condition on the target (may be remote) node, but the `Lookups` plugin accesses data only on the local node (*1).
(*1) http://docs.ansible.com/ansible/playbooks_lookups.html

This patch avoid this problem by reading the file on the target node and setting it to the variable.

Thank you.