### PR TITLE
Assert that forked PR CI really works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ script:
   # run kitchen tests (destroy, create, converge, setup, verify and destroy)
   - kitchen test ${DISTRO}
 
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,3 @@ before_script:
 script:
   # run kitchen tests (destroy, create, converge, setup, verify and destroy)
   - kitchen test ${DISTRO}
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,4 @@ before_script:
 script:
   # run kitchen tests (destroy, create, converge, setup, verify and destroy)
   - kitchen test ${DISTRO}
+

--- a/roles/bwc/defaults/main.yml
+++ b/roles/bwc/defaults/main.yml
@@ -7,7 +7,7 @@ bwc_version: latest
 bwc_revision: 1
 
 # BWC license to install BWC enterprise bits
-master_token: "{{ bwc_license }}"
+bwc_license: null
 
 # Specify roles and assignments for BWC RBAC.
 # Roles are pushed as YML files to /opt/stackstorm/rbac/roles

--- a/roles/bwc/tasks/bwc_repos_setup.yml
+++ b/roles/bwc/tasks/bwc_repos_setup.yml
@@ -1,10 +1,4 @@
 ---
-
-- name: Assert that master_token is specified
-  fail:
-    msg: "License key must be supplied for BWC enterprise installation."
-  when: bwc_license is not defined
-
 - name: Create packagecloud dir
   become: yes
   file:

--- a/roles/bwc/tasks/main.yml
+++ b/roles/bwc/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Assert that 'bwc_license' is specified
+  fail:
+    msg: "License key must be supplied for BWC enterprise installation."
+  when: bwc_license is not defined or bwc_license|length < 48
 
 - name: Add BWC enterprise repos
   include: bwc_repos_setup.yml

--- a/roles/bwc/tasks/main.yml
+++ b/roles/bwc/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- name: Assert that 'bwc_license' is specified
+- name: Assert that 'bwc_license' is specified correctly
   fail:
     msg: "License key must be supplied for BWC enterprise installation."
-  when: bwc_license is not defined or bwc_license|length < 48
+  when: bwc_license is not defined or bwc_license is none or bwc_license|length != 48
 
 - name: Add BWC enterprise repos
   include: bwc_repos_setup.yml

--- a/stackstorm.yml
+++ b/stackstorm.yml
@@ -14,6 +14,6 @@
     - st2chatops
     - st2smoketests
     - role: bwc
-      when: bwc_license is defined and bwc_license is not null
+      when: bwc_license is defined and bwc_license is not none
     - role: bwc_smoketests
-      when: bwc_license is defined and bwc_license is not null
+      when: bwc_license is defined and bwc_license is not none

--- a/stackstorm.yml
+++ b/stackstorm.yml
@@ -14,6 +14,6 @@
     - st2chatops
     - st2smoketests
     - role: bwc
-      when: bwc_license is defined
+      when: bwc_license is defined and bwc_license is not null
     - role: bwc_smoketests
-      when: bwc_license is defined
+      when: bwc_license is defined and bwc_license is not null


### PR DESCRIPTION
Part of the https://github.com/StackStorm/ansible-st2/pull/141 and https://github.com/StackStorm/ansible-st2/pull/143

Check that forked PR CI in Travis really works.
- `st2chatops` role + smoketests should work in forked PR CI
- `bwc` role + smoketests should be skipped for the forked PRs due to license