### PR TITLE
Fix 'st2chatops' smoketests for default 'hubot' adapter

### DIFF
--- a/roles/st2chatops/tasks/main.yml
+++ b/roles/st2chatops/tasks/main.yml
@@ -119,6 +119,7 @@
   when: >
     (enabled_adapter != "{{ st2chatops_hubot_adapter }}") or
     (enabled_adapter is not defined)
+  notify: restart st2chatops
   tags: st2chatops
 
 - name: Uncomment Hubot "{{ st2chatops_hubot_adapter|upper }}" adapter in "/opt/stackstorm/chatops/st2chatops.env"

--- a/roles/st2chatops/tasks/main.yml
+++ b/roles/st2chatops/tasks/main.yml
@@ -117,7 +117,7 @@
     regexp: '^(export HUBOT_ADAPTER=.*)'
     replace: '# \1'
   when: >
-    (enabled_adapter != "{{ st2chatops_hubot_adapter }}") or
+    (enabled_adapter != st2chatops_hubot_adapter) or
     (enabled_adapter is not defined)
   notify: restart st2chatops
   tags: st2chatops

--- a/roles/st2smoketests/tasks/main.yml
+++ b/roles/st2smoketests/tasks/main.yml
@@ -50,15 +50,10 @@
   tags:
     - smoke-tests
 
-- name: Verify st2chatops using bin/hubot
-  command: "timeout 25 bin/hubot"
-  args:
-    chdir: "/opt/stackstorm/chatops/"
-  register: test_output
+- name: Verify st2chatops
+  include: st2chatops.yml
   # st2chatops is installed
   when: st2chatops_version is defined
-  failed_when: "'{{ st2chatops_hubot_adapter|title }} client now connected' not in test_output.stdout or 'DEBUG Added command: st2 list' not in test_output.stdout"
-  changed_when: no
   tags:
     - smoke-tests
     - st2chatops

--- a/roles/st2smoketests/tasks/st2chatops.yml
+++ b/roles/st2smoketests/tasks/st2chatops.yml
@@ -1,28 +1,25 @@
 ---
-- name: Install dependencies for st2chatops smoketests
-  become: yes
-  package:
-    name: python-pexpect
-  changed_when: no
-
-# Expect works better in interactive mode
-- name: Read st2chatops output using bin/hubot
-  become: yes
-  become_user: st2
-  expect:
-    chdir: /opt/stackstorm/chatops
-    command: bin/hubot
-    responses: {}
-    timeout: 5
+- name: Verify st2chatops using bin/hubot
+  shell: (sleep 3; echo "!pack get core"; sleep 3; echo exit ) | bin/hubot
+  args:
+    chdir: /opt/stackstorm/chatops/
+  environment:
+    HUBOT_LOG_LEVEL: debug
+    HUBOT_ALIAS: "!"
   register: hubot_output
-  failed_when: no
   changed_when: no
 
 # Additional task to provide better error message
 - name: Fail if st2chatops couldn't load st2 commands
   fail:
     msg: |
-      There was an error loading st2 commands, please check you 'st2chatops' configuration!
-      The 'bin/hubot' output was:
-      {{ hubot_output.stdout }}
-  when: "'DEBUG Loading adapter {{ st2chatops_hubot_adapter }}' not in hubot_output.stdout or 'DEBUG Added command: st2 list' not in hubot_output.stdout"
+      Please check you 'st2chatops' configuration!
+      Expected message "{{ item }}" not found in 'hubot' output.
+      Full chatops log: {{ hubot_output.stdout }}
+  when: item not in hubot_output.stdout
+  with_items:
+    - "DEBUG Loading adapter {{ st2chatops_hubot_adapter }}"
+    - "DEBUG Loading scripts from /opt/stackstorm/chatops/src/scripts"
+    - "DEBUG Added command: pack get"
+    - "Getting back to you about the installed `core` pack:"
+    - "description: st2 content pack containing basic actions"

--- a/roles/st2smoketests/tasks/st2chatops.yml
+++ b/roles/st2smoketests/tasks/st2chatops.yml
@@ -1,0 +1,28 @@
+---
+- name: Install dependencies for st2chatops smoketests
+  become: yes
+  package:
+    name: python-pexpect
+  changed_when: no
+
+# Expect works better in interactive mode
+- name: Read st2chatops output using bin/hubot
+  become: yes
+  become_user: st2
+  expect:
+    chdir: /opt/stackstorm/chatops
+    command: bin/hubot
+    responses: {}
+    timeout: 5
+  register: hubot_output
+  failed_when: no
+  changed_when: no
+
+# Additional task to provide better error message
+- name: Fail if st2chatops couldn't load st2 commands
+  fail:
+    msg: |
+      There was an error loading st2 commands, please check you 'st2chatops' configuration!
+      The 'bin/hubot' output was:
+      {{ hubot_output.stdout }}
+  when: "'DEBUG Loading adapter {{ st2chatops_hubot_adapter }}' not in hubot_output.stdout or 'DEBUG Added command: st2 list' not in hubot_output.stdout"

--- a/roles/st2smoketests/tasks/st2chatops.yml
+++ b/roles/st2smoketests/tasks/st2chatops.yml
@@ -1,12 +1,13 @@
 ---
 - name: Verify st2chatops using bin/hubot
-  shell: (sleep 3; echo "!pack get core"; sleep 3; echo exit ) | bin/hubot
+  # when editing, make sure it works for at least 2 adapters: 'shell' and 'slack'
+  shell: timeout 10 bash -c '(sleep 5; echo exit ) | bin/hubot'
   args:
     chdir: /opt/stackstorm/chatops/
   environment:
     HUBOT_LOG_LEVEL: debug
-    HUBOT_ALIAS: "!"
   register: hubot_output
+  failed_when: no
   changed_when: no
 
 # Additional task to provide better error message
@@ -21,5 +22,4 @@
     - "DEBUG Loading adapter {{ st2chatops_hubot_adapter }}"
     - "DEBUG Loading scripts from /opt/stackstorm/chatops/src/scripts"
     - "DEBUG Added command: pack get"
-    - "Getting back to you about the installed `core` pack:"
-    - "description: st2 content pack containing basic actions"
+    - "commands are loaded"


### PR DESCRIPTION
Fixes #145

### Improvements
- Fix st2smoketests for default `shell` adapter, failing in Vagrant env
- ~Use interactive `expect` module which works better comparing to non-interactive `timeout 25 bin/hubot` (hangs early before loading commands when using `shell` adapter)~ (not compatible with `EL6`)
- Use `shell` module + step commands for testing `bin/hubot` 
- ~End-to-end test `!pack get core` chatops command and verify result~ (doesn't work for non-shell adapters)
- Show better error message to user when `st2chatops` couldn't load st2 commands
