### PR TITLE
Install MongoDB 3.4 by default

### DIFF
--- a/roles/mongodb/meta/main.yml
+++ b/roles/mongodb/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  description: Install MongoDB-3.2
+  description: Install MongoDB-3.4
   author: humblearner
   company: StackStorm
   license: Apache

--- a/roles/mongodb/tasks/mongodb_apt.yaml
+++ b/roles/mongodb/tasks/mongodb_apt.yaml
@@ -3,14 +3,14 @@
   become: yes
   apt_key:
     keyserver: "hkp://keyserver.ubuntu.com:80"
-    id: 42F3E95A2C4F08279C4960ADD68FA50FEA312927
+    id: 0C49F3730359A14518585931BC711F9BA15703C6
     state: present
   tags: [databases, mongodb]
 
 - name: apt | Add mongodb repository
   become: yes
   apt_repository:
-    repo: 'deb http://repo.mongodb.org/apt/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }}/mongodb-org/3.2 multiverse'
+    repo: 'deb http://repo.mongodb.org/apt/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }}/mongodb-org/3.4 multiverse'
     state: present
   tags: [databases, mongodb]
 

--- a/roles/mongodb/tasks/mongodb_yum.yaml
+++ b/roles/mongodb/tasks/mongodb_yum.yaml
@@ -4,19 +4,19 @@
 - name: yum | Add mongodb key
   become: yes
   rpm_key:
-    key: https://www.mongodb.org/static/pgp/server-3.2.asc
+    key: https://www.mongodb.org/static/pgp/server-3.4.asc
     state: present
   tags: [databases, mongodb]
 
 - name: yum | Add mongodb repository
   become: yes
   yum_repository:
-    name: mongodb-org-3.2
+    name: mongodb-org-3.4
     description: MongoDB Repository
     gpgcheck: yes
     enabled: yes
-    baseurl: https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/x86_64/
-    gpgkey: https://www.mongodb.org/static/pgp/server-3.2.asc
+    baseurl: https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.4/x86_64/
+    gpgkey: https://www.mongodb.org/static/pgp/server-3.4.asc
     state: present
   tags: [databases, mongodb]
 


### PR DESCRIPTION
Part of https://github.com/StackStorm/st2/issues/3592 change.

Since we don't have per version branching in please yet, we should only merge this after v2.4.0 is out.