### PR TITLE
Various Ansible Galaxy cosmetic enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,6 @@ before_script:
 script:
   # run kitchen tests (destroy, create, converge, setup, verify and destroy)
   - kitchen test ${DISTRO}
+
+notifications:
+    webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
+# See also `ansible.cfg.galaxy` if installed from Ansible Galaxy
 [defaults]
 roles_path=roles/

--- a/ansible.cfg.galaxy
+++ b/ansible.cfg.galaxy
@@ -1,0 +1,8 @@
+# If installed `ansible-st2` via ansible-galaxy.
+# All the project roles are located under the 'roles' dir.
+# See why: https://github.com/StackStorm/ansible-st2/issues/45
+#
+# Use this `ansible.cfg` workaround to help Ansible find StackStorm roles:
+
+[defaults]
+roles_path = /etc/ansible/roles/:/etc/ansible/roles/stackstorm/roles/

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,10 +1,14 @@
-# Meta which allows installing `ansible-st2` via ansible-galaxy
-# Workaround for `ansible.cfg` to find stackstorm roles:
+# "Fake role" meta which allows installing `ansible-st2` via ansible-galaxy.
+# All the project roles are located under the 'roles' dir.
+# See why: https://github.com/StackStorm/ansible-st2/issues/45
+#
+# `ansible.cfg` workaround to find stackstorm roles:
+#
 # [defaults]
 # roles_path = /etc/ansible/roles/:/etc/ansible/roles/stackstorm/roles/
 ---
 galaxy_info:
-  description: Install StackStorm with all components and dependant services including RabbitMQ, MongoDB, PostgreSQL, nginx.
+  description: Install StackStorm (IFTTT for Ops) with all the components like Web UI, ChatOps, BWC and dependant services including RabbitMQ, MongoDB, PostgreSQL, nginx.
   author: armab
   company: StackStorm
   license: Apache 2.0
@@ -21,12 +25,16 @@ galaxy_info:
   categories:
     - ops
     - devops
+    - chatops
     - automation
     - remediation
+    - workflows
     - stackstorm
     - st2
     - st2web
     - st2mistral
+    - st2chatops
+    - bwc
     - rabbitmq
     - mongodb
     - postgresql


### PR DESCRIPTION
As experiment, we've added this repo as [`StackStorm.stackstorm`](https://galaxy.ansible.com/StackStorm/stackstorm/) Ansible Galaxy with all the components  (opposed to https://github.com/StackStorm/ansible-st2/issues/45), see [`meta/main.yml`](https://github.com/StackStorm/ansible-st2/blob/master/meta/main.yml) and `ansible.cfg.galaxy` workaround.

This PR adds a bit better descriptions (mostly for experimental use at the moment) if role was installed from Galaxy. Additionally add `travis.yml` webhook so Ansible Galaxy will show the build status badge.

See: https://www.ansible.com/blog/ansible-galaxy-2-release