### PR TITLE
 Add Slack notifications on CI failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,10 @@ script:
   - kitchen test ${DISTRO}
 
 notifications:
-    webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  # Post build failures to '#ansible' channel in 'stackstorm-community' Slack
+  slack:
+    secure: MXJk2ZQKUpRf3xi8aPd9/3yGVaeWLw5xN0mDeTDKJu/IYW/M5obCnO3TYwQGczY1Dd4zkEuUmbOMMix1W5SsSB5Eea4VDtq4rHXxuk625JtzKfLp0pBXcLdJ6gB9aQLqDpIXKusNN2VBhtvh7vzSUzefYja4vSk9JH1Ztm3R1YU0ltXPmH+EPfWo4XhoabBhdU3Fb0MFYOXMQ0YQZtDTLVvAYBqaSrsye5TT9ZYUCDfCvmJH0t1Y0yWPIVLjLp/0f9zRMagQarP2e3CCasjsbVHtC9+vygWaWXGgxfNiqXPHGBCmMT9Wl1E1Gjq3092cPJYlxevu7WupOvinksI6t7KgLubLi9k89/iE3siy6PTwbgvpub/WmJJN8hRY0OAR4F9uHDyrE9pNpL4oOY6P0YblOb1sIjmQKZYjJSgogZ7bi9gZ59/3ZTOZ1z+1H+x5YXG2mTDyFl/fonAG2Fwi8anTh5jswllp4HB0IazPpcfFofUle5tFCM4zpULY2TvTHWvn/LbnzLImnY9qiR6Ysaql55UyBC79y8Fol3pqQhB0HnkTE3viA2dN4u95yzeyC6Mu9gKN9jvMGF5C4WsnmPhB28G5jHH6792CBbID1wFgbYDN8AbcBYeflTbIjZYivD5quRJYMu7swR7FArBfHkEIt+qV0SY23geQYo49lAQ=
+    on_pull_requests: false
+    on_success: change # default: always
+    on_failure: always # default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,6 @@ notifications:
   # Post build failures to '#ansible' channel in 'stackstorm-community' Slack
   slack:
     secure: MXJk2ZQKUpRf3xi8aPd9/3yGVaeWLw5xN0mDeTDKJu/IYW/M5obCnO3TYwQGczY1Dd4zkEuUmbOMMix1W5SsSB5Eea4VDtq4rHXxuk625JtzKfLp0pBXcLdJ6gB9aQLqDpIXKusNN2VBhtvh7vzSUzefYja4vSk9JH1Ztm3R1YU0ltXPmH+EPfWo4XhoabBhdU3Fb0MFYOXMQ0YQZtDTLVvAYBqaSrsye5TT9ZYUCDfCvmJH0t1Y0yWPIVLjLp/0f9zRMagQarP2e3CCasjsbVHtC9+vygWaWXGgxfNiqXPHGBCmMT9Wl1E1Gjq3092cPJYlxevu7WupOvinksI6t7KgLubLi9k89/iE3siy6PTwbgvpub/WmJJN8hRY0OAR4F9uHDyrE9pNpL4oOY6P0YblOb1sIjmQKZYjJSgogZ7bi9gZ59/3ZTOZ1z+1H+x5YXG2mTDyFl/fonAG2Fwi8anTh5jswllp4HB0IazPpcfFofUle5tFCM4zpULY2TvTHWvn/LbnzLImnY9qiR6Ysaql55UyBC79y8Fol3pqQhB0HnkTE3viA2dN4u95yzeyC6Mu9gKN9jvMGF5C4WsnmPhB28G5jHH6792CBbID1wFgbYDN8AbcBYeflTbIjZYivD5quRJYMu7swR7FArBfHkEIt+qV0SY23geQYo49lAQ=
-    on_pull_requests: true
-    on_success: always # default: always
+    on_pull_requests: false
+    on_success: change # default: always
     on_failure: always # default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,6 @@ notifications:
   # Post build failures to '#ansible' channel in 'stackstorm-community' Slack
   slack:
     secure: MXJk2ZQKUpRf3xi8aPd9/3yGVaeWLw5xN0mDeTDKJu/IYW/M5obCnO3TYwQGczY1Dd4zkEuUmbOMMix1W5SsSB5Eea4VDtq4rHXxuk625JtzKfLp0pBXcLdJ6gB9aQLqDpIXKusNN2VBhtvh7vzSUzefYja4vSk9JH1Ztm3R1YU0ltXPmH+EPfWo4XhoabBhdU3Fb0MFYOXMQ0YQZtDTLVvAYBqaSrsye5TT9ZYUCDfCvmJH0t1Y0yWPIVLjLp/0f9zRMagQarP2e3CCasjsbVHtC9+vygWaWXGgxfNiqXPHGBCmMT9Wl1E1Gjq3092cPJYlxevu7WupOvinksI6t7KgLubLi9k89/iE3siy6PTwbgvpub/WmJJN8hRY0OAR4F9uHDyrE9pNpL4oOY6P0YblOb1sIjmQKZYjJSgogZ7bi9gZ59/3ZTOZ1z+1H+x5YXG2mTDyFl/fonAG2Fwi8anTh5jswllp4HB0IazPpcfFofUle5tFCM4zpULY2TvTHWvn/LbnzLImnY9qiR6Ysaql55UyBC79y8Fol3pqQhB0HnkTE3viA2dN4u95yzeyC6Mu9gKN9jvMGF5C4WsnmPhB28G5jHH6792CBbID1wFgbYDN8AbcBYeflTbIjZYivD5quRJYMu7swR7FArBfHkEIt+qV0SY23geQYo49lAQ=
-    on_pull_requests: false
-    on_success: change # default: always
+    on_pull_requests: true
+    on_success: always # default: always
     on_failure: always # default: always


### PR DESCRIPTION
Add Slack notifications per https://docs.travis-ci.com/user/notifications/#Configuring-slack-notifications

This will post build failures to '#ansible' channel in 'stackstorm-community' Slack