### PR TITLE
Update roles path in example ansible.cfg when installing StackStorm from galaxy

### DIFF
--- a/ansible.cfg.galaxy
+++ b/ansible.cfg.galaxy
@@ -5,4 +5,4 @@
 # Use this `ansible.cfg` workaround to help Ansible find StackStorm roles:
 
 [defaults]
-roles_path = /etc/ansible/roles/:/etc/ansible/roles/stackstorm/roles/
+roles_path = /etc/ansible/roles/:/etc/ansible/roles/StackStorm.stackstorm/roles/

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@
 # `ansible.cfg` workaround to find stackstorm roles:
 #
 # [defaults]
-# roles_path = /etc/ansible/roles/:/etc/ansible/roles/stackstorm/roles/
+# roles_path = /etc/ansible/roles/:/etc/ansible/roles/StackStorm.stackstorm/roles/
 ---
 galaxy_info:
   description: Install StackStorm (IFTTT for Ops) with all the components like Web UI, ChatOps, BWC and dependant services including RabbitMQ, MongoDB, PostgreSQL, nginx.


### PR DESCRIPTION
Update the path in example `ansible.cfg` to point to `StackStorm.stackstorm` when installing from Galaxy https://galaxy.ansible.com/StackStorm/stackstorm/