### PR TITLE
Fix 'st2chatops' not adding st2 API key with Ansible 2.4

### DIFF
--- a/roles/st2chatops/tasks/main.yml
+++ b/roles/st2chatops/tasks/main.yml
@@ -45,12 +45,12 @@
     - restart st2chatops
   tags: st2chatops
 
-- name: Check if api key already exist. No change if it already exists
+- name: Check if API key already exist in st2chatops.env
   become: yes
   command: "grep -e '^export ST2_API_KEY=\"\\${ST2_API_KEY}\"$' /opt/stackstorm/chatops/st2chatops.env"
   changed_when: no
   ignore_errors: true
-  register: task_apikey_exists
+  register: task_apikey_not_exists
   tags: st2chatops
 
 - name: Add user defined "st2chatops_st2_api_key" in st2chatops.env, from "role" or "defaults/main.yml"
@@ -60,7 +60,7 @@
     regexp: '(?<=ST2_API_KEY=)(\"\$\{ST2_API_KEY\}\")$'
     replace: '{{ st2chatops_st2_api_key }}'
   when: >
-    (task_apikey_exists.failed is not defined) and
+    (task_apikey_not_exists|succeeded) and
     (st2chatops_st2_api_key is defined) and
     (st2chatops_st2_api_key != "CHANGE-ME-PLEASE")
   register: task_user_st2_api_key
@@ -70,9 +70,7 @@
 
 - name: Generate authentication token
   command: st2 auth {{ st2_auth_username }} -p {{ st2_auth_password }} -t
-  when: >
-    (task_apikey_exists.failed is not defined) and
-    (task_user_st2_api_key.changed == false)
+  when: task_apikey_not_exists|succeeded and task_user_st2_api_key.changed == false
   register: task_st2_token
   tags: [st2chatops, skip_ansible_lint]
 


### PR DESCRIPTION
This fixes the build failure https://travis-ci.org/StackStorm/ansible-st2/jobs/277766176 for `Ubuntu14` and `Ubuntu16` which rely on updated `Ansible 2.4`, while EL6/7 are still on `Ansible 2.3`.

Diff for task results between Ansible 2.3 and 2.4:

```diff
-ok: [Ansible 2.3] => {
+ok: [Ansible 2.4] => {
    "task_apikey_exists": {
        "changed": false, 
        "cmd": [
            "grep", 
            "-e", 
            "^export ST2_API_KEY=\"\\${ST2_API_KEY}\"$", 
            "/opt/stackstorm/chatops/st2chatops.env"
        ], 
        "delta": "0:00:00.002443", 
        "end": "2017-09-21 11:45:23.233013", 
+       "failed": false,
        "rc": 0, 
        "start": "2017-09-21 11:45:23.230570", 
        "stderr": "", 
        "stderr_lines": [], 
        "stdout": "export ST2_API_KEY=\"${ST2_API_KEY}\"", 
        "stdout_lines": [
            "export ST2_API_KEY=\"${ST2_API_KEY}\""
        ]
    }
}
```

With that, relying on `task_apikey_exists.failed is not defined` lead to logic mistake.

As a result task didn't generate & add st2 API Key to `st2chatops.env` leading in `st2chatops` not configured to auth with StackStorm:
```
ERROR Failed to authenticate: Invalid or missing credentials
```