### PR TITLE
Remove BWC RBAC directories creation

### DIFF
--- a/roles/bwc/tasks/rbac.yml
+++ b/roles/bwc/tasks/rbac.yml
@@ -1,17 +1,4 @@
 ---
-
-  - name: Create BWC RBAC directories
-    become: yes
-    file:
-      path: "{{ item }}"
-      mode: "u=rwx,g=rx,o=rx"
-      owner: st2
-      group: st2
-      state: directory
-    with_items:
-      - /opt/stackstorm/rbac/assignments
-      - /opt/stackstorm/rbac/roles
-
   - name: Copy default RBAC roles to /opt/stackstorm/rbac/roles directory
     become: yes
     template:


### PR DESCRIPTION
The directory creation and permissions/ownership is done by the deb/rpm packaging now.

The build will :white_check_mark: once the change is merged in upstream.
