### PR TITLE
Configure proxy settings for stackstorm services

### DIFF
--- a/roles/st2/handlers/main.yml
+++ b/roles/st2/handlers/main.yml
@@ -9,6 +9,12 @@
   become: yes
   command: st2ctl reload --register-all
 
+- name: restart st2actionrunner
+  become: yes
+  service:
+    name: st2actionrunner
+    state: restarted
+
 - name: restart st2api
   become: yes
   service:

--- a/roles/st2/tasks/main.yml
+++ b/roles/st2/tasks/main.yml
@@ -64,6 +64,10 @@
   include: datastore.yml
   tags: st2, datastore
 
+- name: Configure StackStorm to work via proxy
+  include: proxy.yml
+  tags: st2, proxy
+
 - name: Ensure StackStorm services are enabled and running
   become: yes
   service:

--- a/roles/st2/tasks/proxy.yml
+++ b/roles/st2/tasks/proxy.yml
@@ -1,0 +1,17 @@
+---
+# Update proxy env vars in StackStorm service config files
+- name: proxy | Configure StackStorm services
+  become: yes
+  lineinfile:
+    dest: /etc/{{ 'default' if ansible_pkg_mgr == 'apt' else 'sysconfig' }}/{{ item.0 }}
+    create: yes
+    regexp: '^{{ item.1 }}='
+    line: "{{ item.1}}={{ ansible_env.get(item.1) }}"
+    # NB: Empty ENV var cast to 'None' string in Ansible
+    state: "{{ 'present' if ansible_env.get(item.1, 'None') != 'None' else 'absent' }}"
+  with_nested:
+    - [st2api, st2actionrunner]
+    - [http_proxy, https_proxy, no_proxy]
+  notify:
+    - restart st2actionrunner
+    - restart st2api


### PR DESCRIPTION
Closes #178 

Enable configuring proxy settings for StackStorm services when `proxy` environment variables are set.

See: https://docs.stackstorm.com/latest/packs.html#proxy-configuration-via-environment-variables for what's exactly configured

This is required for `st2 pack install` work via proxy.