### PR TITLE
Remove explicit st2python <> st2mistral dependency under EL6

### DIFF
--- a/roles/st2mistral/tasks/main.yml
+++ b/roles/st2mistral/tasks/main.yml
@@ -1,12 +1,4 @@
 ---
-- name: Install st2python dependency for EL6
-  become: yes
-  package:
-    name: st2python
-    state: present
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
-  tags: st2mistral
-
 - name: Install latest st2mistral package, auto-update
   become: yes
   package:


### PR DESCRIPTION
The task is not necessary since https://github.com/StackStorm/st2-packages/pull/518 `st2python` dependency is included in rpm packaging for `st2mistral`.