### PR TITLE
Add drivername to mistral database connection string

### DIFF
--- a/roles/st2mistral/tasks/main.yml
+++ b/roles/st2mistral/tasks/main.yml
@@ -73,7 +73,7 @@
     dest: /etc/mistral/mistral.conf
     section: database
     option: connection
-    value: postgresql://{{ st2mistral_db_username }}:{{ st2mistral_db_password }}@localhost/{{ st2mistral_db }}
+    value: postgresql+psycopg2://{{ st2mistral_db_username }}:{{ st2mistral_db_password }}@localhost/{{ st2mistral_db }}
     backup: yes
   # no_log to prevent plain text logging of the password
   no_log: yes


### PR DESCRIPTION
Use dbname+drivername as described in StackStorm/st2-packages#490.

Related:
StackStorm/st2-packages#491
StackStorm/st2-docker#64