### PR TITLE
st2chatops: allow auth passwords with spaces in "st2 auth" command

### DIFF
--- a/roles/st2chatops/tasks/main.yml
+++ b/roles/st2chatops/tasks/main.yml
@@ -69,7 +69,7 @@
   tags: st2chatops
 
 - name: Generate authentication token
-  command: st2 auth {{ st2_auth_username }} -p {{ st2_auth_password }} -t
+  command: st2 auth {{ st2_auth_username }} -p "{{ st2_auth_password }}" -t
   when: task_apikey_not_exists|succeeded and task_user_st2_api_key.changed == false
   register: task_st2_token
   tags: [st2chatops, skip_ansible_lint]

--- a/roles/st2chatops/tasks/main.yml
+++ b/roles/st2chatops/tasks/main.yml
@@ -69,7 +69,7 @@
   tags: st2chatops
 
 - name: Generate authentication token
-  command: st2 auth {{ st2_auth_username }} -p "{{ st2_auth_password }}" -t
+  command: st2 auth "{{ st2_auth_username }}" -p "{{ st2_auth_password }}" -t
   when: task_apikey_not_exists|succeeded and task_user_st2_api_key.changed == false
   register: task_st2_token
   tags: [st2chatops, skip_ansible_lint]

--- a/roles/st2smoketests/tasks/main.yml
+++ b/roles/st2smoketests/tasks/main.yml
@@ -19,7 +19,7 @@
     - smoke-tests
 
 - name: get authentication token
-  command: st2 auth {{ st2_auth_username }} -p {{ st2_auth_password }} -t
+  command: st2 auth {{ st2_auth_username }} -p "{{ st2_auth_password }}" -t
   register: st2_token
   changed_when: no
   tags:

--- a/roles/st2smoketests/tasks/main.yml
+++ b/roles/st2smoketests/tasks/main.yml
@@ -19,7 +19,7 @@
     - smoke-tests
 
 - name: get authentication token
-  command: st2 auth {{ st2_auth_username }} -p "{{ st2_auth_password }}" -t
+  command: st2 auth "{{ st2_auth_username }}" -p "{{ st2_auth_password }}" -t
   register: st2_token
   changed_when: no
   tags:


### PR DESCRIPTION
Passwords with spaces were passed incorrectly because of missing quotes. This caused the executed command to fail as the space separated parts were each used as argument instead of as one argument.