### PR TITLE
Fix nginx installing from EPEL repo

### DIFF
--- a/roles/nginx/tasks/nginx_yum.yml
+++ b/roles/nginx/tasks/nginx_yum.yml
@@ -22,6 +22,7 @@
   yum:
     name: nginx
     state: present
+    disablerepo: epel
   tags: nginx
 
 - name: Remove default site


### PR DESCRIPTION
Originally we install `nginx` from the `nxing.org` official repo which has `1:1.12.2-1` version.
A few days ago EPEL released new version of nginx `1:1.12.2-2.el7` which now takes precedence over the nginx.org version and get installed.

EPEL version of nginx comes with other dependencies, directory structure which resulted in broken nginx config after running this role:
```
       RUNNING HANDLER [nginx : restart nginx] ****************************************
       fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unable to restart service nginx: Job for nginx.service failed because the control process exited with error code. See \"systemctl status nginx.service\" and \"journalctl -xe\" for details.\n"}
```

Fix nginx role to exclude `epel` repo while installing the package.