### PR TITLE
Add task retries in case of connection failure

### DIFF
--- a/roles/bwc/tasks/bwc_repos_apt.yml
+++ b/roles/bwc/tasks/bwc_repos_apt.yml
@@ -8,6 +8,10 @@
   with_items:
     - debian-archive-keyring
     - apt-transport-https
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
 
 # This is the exact key as the open source repo but this behavior might change.
 - name: Add keys to keyring
@@ -16,6 +20,10 @@
     id: 418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB
     url: https://packagecloud.io/StackStorm/{{ bwc_repo }}/gpgkey
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
 
 - name: "Add packagecloud.io repository: StackStorm/{{ bwc_repo }}"
   become: yes
@@ -26,3 +34,6 @@
     state: present
     update_cache: yes
   register: added_bwc_deb_repository
+  retries: 5
+  delay: 3
+  until: added_bwc_deb_repository is succeeded

--- a/roles/bwc/tasks/bwc_repos_setup.yml
+++ b/roles/bwc/tasks/bwc_repos_setup.yml
@@ -25,6 +25,10 @@
     headers:
       Content-Type: "application/x-www-form-urlencoded"
     body: "name={{ ansible_nodename }}"
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
 
 - name: Read bwc_read_token from file
   become: yes

--- a/roles/bwc/tasks/bwc_repos_yum.yml
+++ b/roles/bwc/tasks/bwc_repos_yum.yml
@@ -6,6 +6,10 @@
   yum:
     name: ca-certificates
     state: latest
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: skip_ansible_lint
 
 - name: "Add packagecloud.io repository: StackStorm/{{ bwc_repo }}"

--- a/roles/bwc/tasks/main.yml
+++ b/roles/bwc/tasks/main.yml
@@ -16,6 +16,9 @@
     name: bwc-enterprise
     state: latest
   register: bwc_installed
+  retries: 5
+  delay: 3
+  until: bwc_installed is succeeded
   when: bwc_version == "latest"
   tags:
     - bwc
@@ -28,6 +31,9 @@
     name: bwc-enterprise
     state: present
   register: bwc_installed
+  retries: 5
+  delay: 3
+  until: bwc_installed is succeeded
   when: bwc_version == "present"
   tags:
     - bwc
@@ -39,6 +45,9 @@
     name: bwc-enterprise{{ '-' if ansible_pkg_mgr == 'yum' else '=' }}{{ bwc_version }}-{{ bwc_revision }}
     state: present
   register: bwc_installed
+  retries: 5
+  delay: 3
+  until: bwc_installed is succeeded
   when:
     - bwc_version != "latest"
     - bwc_version != "present"

--- a/roles/epel/tasks/main.yml
+++ b/roles/epel/tasks/main.yml
@@ -11,5 +11,9 @@
   yum:
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when: ansible_os_family == "RedHat" and not epel_installed.stat.exists
   tags: epel

--- a/roles/mongodb/tasks/mongodb_apt.yml
+++ b/roles/mongodb/tasks/mongodb_apt.yml
@@ -6,6 +6,10 @@
     keyserver: "hkp://keyserver.ubuntu.com:80"
     id: "{{ mongodb_apt_keys[mongodb_major_minor_version] }}"
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: [databases, mongodb]
 
 - name: apt | Add mongodb repository
@@ -20,6 +24,10 @@
   apt:
     name: "{{ item }}={{ mongodb_version }}*"
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   with_items:
     # re-installing different version of 'mongodb-org' meta package doesn't automatically
     # upgrade or downgrade its dependencies. So we need to explicitly list them one-by-one.

--- a/roles/mongodb/tasks/mongodb_yum.yml
+++ b/roles/mongodb/tasks/mongodb_yum.yml
@@ -1,7 +1,13 @@
 ---
 - name: yum | Install mongodb dependencies
   become: yes
-  yum: name={{item}} state=present
+  yum:
+    name: "{{ item }}"
+    state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   with_items:
     # Failed to validate the SSL certificate for www.mongodb.org:443. Make sure your managed systems have a valid CA certificate installed. If the website serving the url uses SNI you need python >= 2.7.9 on your managed machine or you can install the `urllib3`, `pyopenssl`, `ndg-httpsclient`, and `pyasn1` python modules to perform SNI verification in python >= 2.6. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible
     - python-urllib3
@@ -14,6 +20,10 @@
   rpm_key:
     key: https://www.mongodb.org/static/pgp/server-{{ mongodb_major_minor_version }}.asc
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: [databases, mongodb]
 
 - name: yum | Add mongodb repository
@@ -36,6 +46,10 @@
     # TODO: Allow yum downgrade since Ansible 2.4
     # https://github.com/ansible/ansible/pull/21516
     # allow_downgrade: yes
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   notify:
     - restart mongodb
   tags: [databases, mongodb]

--- a/roles/nginx/tasks/nginx_apt.yml
+++ b/roles/nginx/tasks/nginx_apt.yml
@@ -5,6 +5,10 @@
     url: http://nginx.org/keys/nginx_signing.key
     id: 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: nginx
 
 - name: Add nginx repos
@@ -19,6 +23,10 @@
   apt:
     name: nginx
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: nginx
 
 - name: Remove default site

--- a/roles/nginx/tasks/nginx_yum.yml
+++ b/roles/nginx/tasks/nginx_yum.yml
@@ -4,6 +4,10 @@
   rpm_key:
     key: http://nginx.org/keys/nginx_signing.key
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: nginx
 
 - name: Add nginx repos
@@ -23,6 +27,10 @@
     name: nginx
     state: present
     disablerepo: epel
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: nginx
 
 - name: Remove default site
@@ -38,6 +46,9 @@
     name: libsemanage-python, libselinux-python
     state: present
   register: nginx_selinux_dependencies
+  retries: 5
+  delay: 3
+  until: nginx_selinux_dependencies is succeeded
   tags: nginx
 
 - name: Update SELinux facts after installing dependencies

--- a/roles/nodejs/tasks/nodejs_apt.yml
+++ b/roles/nodejs/tasks/nodejs_apt.yml
@@ -3,6 +3,10 @@
   apt:
     name: apt-transport-https
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: nodejs
 
 - name: Add nodesource key
@@ -11,6 +15,10 @@
     url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
     id: "68576280"
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: nodejs
 
 - name: Add nodesource repos debs
@@ -27,4 +35,8 @@
   apt:
     name: nodejs={{ nodejs_major_version }}.*
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: nodejs

--- a/roles/nodejs/tasks/nodejs_apt.yml
+++ b/roles/nodejs/tasks/nodejs_apt.yml
@@ -24,10 +24,8 @@
 - name: Add nodesource repos debs
   become: yes
   apt_repository:
-    repo: "{{ item }}"
+    repo: "deb https://deb.nodesource.com/node_{{ nodejs_major_version }}.x {{ ansible_distribution_release }} main"
     state: present
-  with_items:
-    - "deb https://deb.nodesource.com/node_{{ nodejs_major_version }}.x {{ ansible_distribution_release }} main"
   tags: nodejs
 
 - name: Install nodejs

--- a/roles/nodejs/tasks/nodejs_yum.yml
+++ b/roles/nodejs/tasks/nodejs_yum.yml
@@ -4,6 +4,10 @@
   rpm_key:
     key: http://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: nodejs
 
 - name: Add nodesource repo
@@ -21,4 +25,8 @@
     # TODO: Allow yum downgrade since Ansible 2.4
     # https://github.com/ansible/ansible/pull/21516
     # allow_downgrade: yes
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: nodejs

--- a/roles/postgresql/tasks/postgresql_apt.yml
+++ b/roles/postgresql/tasks/postgresql_apt.yml
@@ -4,6 +4,10 @@
   apt:
     name: postgresql
     state: installed
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: [db, postgresql]
 
 - name: apt | Start and Enable PostgreSQL

--- a/roles/postgresql/tasks/postgresql_yum6.yml
+++ b/roles/postgresql/tasks/postgresql_yum6.yml
@@ -4,6 +4,10 @@
   yum:
     name: https://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-3.noarch.rpm
     state: installed
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when: ansible_distribution == "CentOS"
   tags: [db, postgresql]
 
@@ -12,6 +16,10 @@
   yum:
     name: https://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-redhat94-9.4-3.noarch.rpm
     state: installed
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when: ansible_distribution == "RedHat"
   tags: [db, postgresql]
 
@@ -20,6 +28,10 @@
   yum:
     name: libselinux-python
     state: installed
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: [db, postgresql]
 
 - name: yum | Install PostgreSQL-9.4
@@ -32,6 +44,9 @@
     - postgresql94-contrib
     - postgresql94-devel
   register: install_postgresql
+  retries: 5
+  delay: 3
+  until: install_postgresql is succeeded
   tags: [db, postgresql]
 
 - name: yum | Initialize PostgreSQL-9.4

--- a/roles/postgresql/tasks/postgresql_yum7.yml
+++ b/roles/postgresql/tasks/postgresql_yum7.yml
@@ -9,6 +9,9 @@
     - postgresql-contrib
     - postgresql-devel
   register: install_postgresql
+  retries: 5
+  delay: 3
+  until: install_postgresql is succeeded
   tags: [db, postgresql]
 
 - name: yum | Initialize PostgreSQL

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -4,6 +4,10 @@
   package:
     name: rabbitmq-server
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   notify:
     - restart rabbitmq
   tags: rabbitmq

--- a/roles/st2/tasks/auth.yml
+++ b/roles/st2/tasks/auth.yml
@@ -6,6 +6,10 @@
   with_items:
     - python-passlib
     - apache2-utils
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when: ansible_os_family == 'Debian'
 
 - name: auth | Install auth pre-reqs (RedHat)
@@ -16,6 +20,10 @@
   with_items:
     - python-passlib
     - httpd-tools
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when: ansible_os_family == 'RedHat'
 
 - name: auth | Create htpasswd file

--- a/roles/st2/tasks/main.yml
+++ b/roles/st2/tasks/main.yml
@@ -4,6 +4,10 @@
   package:
     name: http://rpmfind.net/linux/centos/6/os/x86_64/Packages/libffi-devel-3.0.5-3.2.el6.x86_64.rpm
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
   tags: st2
 
@@ -12,6 +16,10 @@
   package:
     name: st2
     state: latest
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when: st2_version == "latest"
   notify:
     - restart st2
@@ -23,6 +31,10 @@
   package:
     name: st2
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when: st2_version == "present"
   notify:
     - restart st2
@@ -34,6 +46,10 @@
   package:
     name: st2{{ '-' if ansible_pkg_mgr == 'yum' else '=' }}{{ st2_version }}-{{ st2_revision }}
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when:
     - st2_version != "latest"
     - st2_version != "present"

--- a/roles/st2chatops/tasks/main.yml
+++ b/roles/st2chatops/tasks/main.yml
@@ -20,6 +20,10 @@
   package:
     name: st2chatops
     state: latest
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when: st2chatops_version == "latest"
   notify:
     - restart st2chatops
@@ -30,6 +34,10 @@
   package:
     name: st2chatops
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when: st2chatops_version == "present"
   notify:
     - restart st2chatops
@@ -40,6 +48,10 @@
   package:
     name: st2chatops{{ '-' if ansible_pkg_mgr == 'yum' else '=' }}{{ st2chatops_version }}
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when: st2chatops_version != "latest"
   notify:
     - restart st2chatops

--- a/roles/st2mistral/tasks/main.yml
+++ b/roles/st2mistral/tasks/main.yml
@@ -6,6 +6,9 @@
     state: latest
   when: st2mistral_version == "latest"
   register: mistral_install_latest
+  retries: 5
+  delay: 3
+  until: mistral_install_latest is succeeded
   tags: [st2mistral, skip_ansible_lint]
 
 - name: Install present st2mistral package, no auto-update
@@ -15,6 +18,9 @@
     state: present
   when: st2mistral_version == "present"
   register: mistral_install_present
+  retries: 5
+  delay: 3
+  until: mistral_install_present is succeeded
   tags: st2mistral
 
 - name: Install pinned st2mistral package
@@ -26,6 +32,9 @@
     - st2mistral_version != "latest"
     - st2mistral_version != "present"
   register: mistral_install_tagged
+  retries: 5
+  delay: 3
+  until: mistral_install_tagged is succeeded
   tags: st2mistral
 
 - name: Enable mistral db upgrade

--- a/roles/st2repo/tasks/st2repo_apt.yml
+++ b/roles/st2repo/tasks/st2repo_apt.yml
@@ -4,6 +4,10 @@
   apt:
     name: "{{ item }}"
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   with_items:
     - debian-archive-keyring
     - apt-transport-https
@@ -14,6 +18,10 @@
     id: 418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB
     url: https://packagecloud.io/StackStorm/{{ st2repo_name }}/gpgkey
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
 
 - name: Add StackStorm repo
   become: yes

--- a/roles/st2repo/tasks/st2repo_yum.yml
+++ b/roles/st2repo/tasks/st2repo_yum.yml
@@ -5,6 +5,10 @@
   yum:
     name: ca-certificates
     state: latest
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   tags: skip_ansible_lint
 
 # See: https://github.com/docker-library/docs/tree/master/centos#package-documentation

--- a/roles/st2web/tasks/main.yml
+++ b/roles/st2web/tasks/main.yml
@@ -16,6 +16,10 @@
   package:
     name: "{{ st2web_package_name }}"
     state: latest
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when: st2_version == "latest"
   tags: st2web, skip_ansible_lint
 
@@ -24,6 +28,10 @@
   package:
     name: "{{ st2web_package_name }}"
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when: st2_version == "present"
   tags: st2web
 
@@ -32,6 +40,10 @@
   package:
     name: "{{ st2web_package_name }}{{ '-' if ansible_pkg_mgr == 'yum' else '=' }}{{ st2_version }}-{{ st2web_revision }}"
     state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
   when:
     - st2_version != "latest"
     - st2_version != "present"


### PR DESCRIPTION
Closes #151 (Retry logic for the connection-oriented commands)

The most-frequent random error when installing StackStorm is related to downloading packages or similar download-oriented operations (connection closed, 50X, SSL broken pipe, GnuTLS recv error, etc). All temporary.

Adding retry on failure logic where applicable.

- [x] epel
- [x] mongodb
- [x] rabbitmq
- [x] st2repo
- [x] st2
- [x] nginx
- [x] st2web
- [x] nodejs
- [x] st2chatops
- [x] postgresql
- [x] st2mistral
- [x] bwc
