### PR TITLE
Lower yum log level to avoid travis log length limit on centos-6

### DIFF
--- a/.kitchen-docker/centos6/Dockerfile
+++ b/.kitchen-docker/centos6/Dockerfile
@@ -11,3 +11,7 @@ RUN touch /home/<%= @username %>/.ssh/authorized_keys
 RUN chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys
 RUN chmod 0600 /home/<%= @username %>/.ssh/authorized_keys
 RUN echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys
+
+# yum output is too verbose (and includes expensive download progress bars)
+# which tripped the travis log length limit for centos-6
+RUN /bin/sed -i "s/^[#]*debuglevel=.*/debuglevel=1/" /etc/yum.conf


### PR DESCRIPTION
This is an optimization for tests that run on Travis.

Got this error when beginning the second suite of tests
> The job exceeded the maximum log length, and has been terminated.

Other platforms do not have as many progress bars.

Compare these build logs to see why the YUM Progress bars are so
problematic.

without this change:
https://api.travis-ci.org/v3/job/430822100/log.txt
with this change:
https://api.travis-ci.org/v3/job/431074530/log.txt

Look below the line that includes:
>   Retrieving https://dl.fedoraproject.org/pub/epel

You will see pages and pages of useless epel/other download progress bars.