### PR TITLE
Multiple kitchen test suites default to same playbook

### DIFF
--- a/test/integration/default.yml
+++ b/test/integration/default.yml
@@ -1,0 +1,1 @@
+../../stackstorm.yml

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -1,1 +1,0 @@
-../../../stackstorm.yml


### PR DESCRIPTION
This makes sure that when any new test suites get added, they all use
the same playbook (stackstorm.yml) by default, no matter what the test
suite is named. If the suite needs a different playbook, the override
can be placed in test/integration/<suite name>/default.yml