### PR TITLE
Add pymongo, a dep of mongodb_user ansible module

### DIFF
--- a/roles/mongodb/tasks/mongodb_auth.yml
+++ b/roles/mongodb/tasks/mongodb_auth.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure pymongo is installed for the mongodb_user ansible module
+  become: yes
+  package:
+    name: python-pymongo
+    state: present


### PR DESCRIPTION
This adds a stub tasks file for adding auth to mongo. Currently, it is not imported/included anywhere.
We'll only include/import this once we're satisfied that it is complete and ready to use.
The only task in this stub file so far is adding pymongo, a dep of the mongodb_user ansible module.

Ansible [docs](https://docs.ansible.com/ansible/2.4/mongodb_user_module.html) mention (in the comment to an example near the end) that
pymongo 2.5+ is supported, so system level packages work for all
platforms.
- CentOS 6 -> EPEL -> python-pymongo-2.5.2
- CentOS 7 -> EPEL -> python-pymongo-2.5.2
- Ubuntu 14.04 -> python-pymongo_2.6.3
- Ubuntu 16.04 -> python-pymongo_3.2