### PR TITLE
Fix deprecated warnings with Ansible 2.7

### DIFF
--- a/roles/bwc/tasks/bwc_repos_apt.yml
+++ b/roles/bwc/tasks/bwc_repos_apt.yml
@@ -3,11 +3,10 @@
 - name: Install prereqs (Debian)
   become: yes
   apt:
-    name: "{{ item }}"
+    name:
+      - debian-archive-keyring
+      - apt-transport-https
     state: present
-  with_items:
-    - debian-archive-keyring
-    - apt-transport-https
   register: _task
   retries: 5
   delay: 3

--- a/roles/mongodb/tasks/mongodb_apt.yml
+++ b/roles/mongodb/tasks/mongodb_apt.yml
@@ -22,19 +22,18 @@
 - name: apt | Install mongodb
   become: yes
   apt:
-    name: "{{ item }}={{ mongodb_version }}*"
+    name:
+      # re-installing different version of 'mongodb-org' meta package doesn't automatically
+      # upgrade or downgrade its dependencies. So we need to explicitly list them one-by-one.
+      - mongodb-org={{ mongodb_version }}*
+      - mongodb-org-shell={{ mongodb_version }}*
+      - mongodb-org-server={{ mongodb_version }}*
+      - mongodb-org-mongos={{ mongodb_version }}*
+      - mongodb-org-tools={{ mongodb_version }}*
     state: present
   register: _task
   retries: 5
   delay: 3
   until: _task is succeeded
-  with_items:
-    # re-installing different version of 'mongodb-org' meta package doesn't automatically
-    # upgrade or downgrade its dependencies. So we need to explicitly list them one-by-one.
-    - mongodb-org
-    - mongodb-org-shell
-    - mongodb-org-server
-    - mongodb-org-mongos
-    - mongodb-org-tools
   notify: restart mongodb
   tags: [databases, mongodb]

--- a/roles/mongodb/tasks/mongodb_yum.yml
+++ b/roles/mongodb/tasks/mongodb_yum.yml
@@ -2,18 +2,17 @@
 - name: yum | Install mongodb dependencies
   become: yes
   yum:
-    name: "{{ item }}"
+    name:
+      # Failed to validate the SSL certificate for www.mongodb.org:443. Make sure your managed systems have a valid CA certificate installed. If the website serving the url uses SNI you need python >= 2.7.9 on your managed machine or you can install the `urllib3`, `pyopenssl`, `ndg-httpsclient`, and `pyasn1` python modules to perform SNI verification in python >= 2.6. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible
+      - python-urllib3
+      - pyOpenSSL
+      - python-pyasn1
+      - python-ndg_httpsclient
     state: present
   register: _task
   retries: 5
   delay: 3
   until: _task is succeeded
-  with_items:
-    # Failed to validate the SSL certificate for www.mongodb.org:443. Make sure your managed systems have a valid CA certificate installed. If the website serving the url uses SNI you need python >= 2.7.9 on your managed machine or you can install the `urllib3`, `pyopenssl`, `ndg-httpsclient`, and `pyasn1` python modules to perform SNI verification in python >= 2.6. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible
-    - python-urllib3
-    - pyOpenSSL
-    - python-pyasn1
-    - python-ndg_httpsclient
 
 - name: yum | Add mongodb key
   become: yes

--- a/roles/postgresql/tasks/postgresql_apt.yml
+++ b/roles/postgresql/tasks/postgresql_apt.yml
@@ -3,7 +3,7 @@
   become: yes
   apt:
     name: postgresql
-    state: installed
+    state: present
   register: _task
   retries: 5
   delay: 3

--- a/roles/postgresql/tasks/postgresql_yum6.yml
+++ b/roles/postgresql/tasks/postgresql_yum6.yml
@@ -37,12 +37,11 @@
 - name: yum | Install PostgreSQL-9.4
   become: yes
   yum:
-    name: "{{ item }}"
+    name:
+      - postgresql94-server
+      - postgresql94-contrib
+      - postgresql94-devel
     state: installed
-  with_items:
-    - postgresql94-server
-    - postgresql94-contrib
-    - postgresql94-devel
   register: install_postgresql
   retries: 5
   delay: 3

--- a/roles/postgresql/tasks/postgresql_yum6.yml
+++ b/roles/postgresql/tasks/postgresql_yum6.yml
@@ -3,7 +3,7 @@
   become: yes
   yum:
     name: https://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-3.noarch.rpm
-    state: installed
+    state: present
   register: _task
   retries: 5
   delay: 3
@@ -15,7 +15,7 @@
   become: yes
   yum:
     name: https://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-redhat94-9.4-3.noarch.rpm
-    state: installed
+    state: present
   register: _task
   retries: 5
   delay: 3
@@ -27,7 +27,7 @@
   become: yes
   yum:
     name: libselinux-python
-    state: installed
+    state: present
   register: _task
   retries: 5
   delay: 3
@@ -41,7 +41,7 @@
       - postgresql94-server
       - postgresql94-contrib
       - postgresql94-devel
-    state: installed
+    state: present
   register: install_postgresql
   retries: 5
   delay: 3

--- a/roles/postgresql/tasks/postgresql_yum7.yml
+++ b/roles/postgresql/tasks/postgresql_yum7.yml
@@ -2,12 +2,11 @@
 - name: yum | Install PostgreSQL
   become: yes
   yum:
-    name: "{{ item }}"
+    name:
+      - postgresql-server
+      - postgresql-contrib
+      - postgresql-devel
     state: installed
-  with_items:
-    - postgresql-server
-    - postgresql-contrib
-    - postgresql-devel
   register: install_postgresql
   retries: 5
   delay: 3

--- a/roles/postgresql/tasks/postgresql_yum7.yml
+++ b/roles/postgresql/tasks/postgresql_yum7.yml
@@ -6,7 +6,7 @@
       - postgresql-server
       - postgresql-contrib
       - postgresql-devel
-    state: installed
+    state: present
   register: install_postgresql
   retries: 5
   delay: 3

--- a/roles/st2/tasks/auth.yml
+++ b/roles/st2/tasks/auth.yml
@@ -1,11 +1,10 @@
 - name: auth | Install auth pre-reqs (Debian)
   become: yes
   apt:
-    name: "{{ item }}"
+    name:
+      - python-passlib
+      - apache2-utils
     state: present
-  with_items:
-    - python-passlib
-    - apache2-utils
   register: _task
   retries: 5
   delay: 3
@@ -15,11 +14,10 @@
 - name: auth | Install auth pre-reqs (RedHat)
   become: yes
   yum:
-    name: "{{ item }}"
+    name:
+      - python-passlib
+      - httpd-tools
     state: present
-  with_items:
-    - python-passlib
-    - httpd-tools
   register: _task
   retries: 5
   delay: 3

--- a/roles/st2repo/tasks/st2repo_apt.yml
+++ b/roles/st2repo/tasks/st2repo_apt.yml
@@ -2,15 +2,14 @@
 - name: Install prereqs (Debian)
   become: yes
   apt:
-    name: "{{ item }}"
+    name:
+      - debian-archive-keyring
+      - apt-transport-https
     state: present
   register: _task
   retries: 5
   delay: 3
   until: _task is succeeded
-  with_items:
-    - debian-archive-keyring
-    - apt-transport-https
 
 - name: Add keys to keyring
   become: yes


### PR DESCRIPTION
This PR fixes two issues:
1. Referenced in issue: https://github.com/StackStorm/ansible-st2/issues/203
2. Use state=present instead of state=installed for apt/yum module.

Closes #203 