### PR TITLE
Fix ansible-lint warnings about using Jinja expressions in 'when'

### DIFF
--- a/roles/bwc/tasks/license.yml
+++ b/roles/bwc/tasks/license.yml
@@ -37,12 +37,12 @@
   file:
     path: "/etc/packagecloud/StackStorm_{{ bwc_repo }}_read_token.txt"
     state: absent
-  when: '"{{ bwc_license | hash("sha512") }}" != "{{ bwc_license_hash }}"'
+  when: bwc_license | hash("sha512") != bwc_license_hash
 
 - name: "Cleanup repo list file from disk"
   become: yes
   include: "bwc_repos_cleanup_{{ ansible_pkg_mgr }}.yml"
-  when: '"{{ bwc_license | hash("sha512") }}" != "{{ bwc_license_hash }}"'
+  when: bwc_license | hash("sha512") != bwc_license_hash
 
 - name: Write new bwc_license_hash to file
   copy:
@@ -51,4 +51,4 @@
     force: yes
   become: yes
   no_log: yes
-  when: '"{{ bwc_license | hash("sha512") }}" != "{{ bwc_license_hash }}"'
+  when: bwc_license | hash("sha512") != bwc_license_hash


### PR DESCRIPTION
https://circleci.com/gh/StackStorm/ansible-st2/649

Fixing 
```
Examining roles/st2/tasks/config.yml of type playbook
[102] No Jinja2 in when
/root/project/roles/bwc/tasks/license.yml:35
Task/Handler: Cleanup read token cached file from disk

[102] No Jinja2 in when
/root/project/roles/bwc/tasks/license.yml:47
Task/Handler: Write new bwc_license_hash to file

Exited with code 2
```

As seen in https://github.com/StackStorm/ansible-st2/pull/208
