### PR TITLE
Changed use of Jinja filters as tests

### DIFF
--- a/roles/st2mistral/tasks/main.yml
+++ b/roles/st2mistral/tasks/main.yml
@@ -45,7 +45,7 @@
   with_items:
     - /etc/mistral/mistral-db-manage.upgrade.head.ansible.has.run
     - /etc/mistral/mistral-db-manage.populate.ansible.has.run
-  when: mistral_install_latest|changed or mistral_install_present|changed or mistral_install_tagged|changed
+  when: mistral_install_latest is changed or mistral_install_present is changed or mistral_install_tagged is changed
   tags: st2mistral, skip_ansible_lint
 
 - name: Deploy database init script


### PR DESCRIPTION
The use of `when mistral_install_latest|changed` is now [deprecated](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters).

This should be `when mistral_install_latest is changed`

Looks like this will require a minimum Ansible version of 2.5, but this is also the oldest version supported by upstream. We should plan to change our [minimum Ansible version to 2.5](https://github.com/StackStorm/ansible-st2/issues/190).