### PR TITLE
Add new service 'st2scheduler', implement st2-version dependent logic

### DIFF
--- a/roles/st2/tasks/main.yml
+++ b/roles/st2/tasks/main.yml
@@ -58,6 +58,10 @@
     - reload st2
   tags: st2
 
+- name: Perform st2 version related operations
+  include: version.yml
+  tags: st2, version
+
 - name: Create and configure StackStorm system user
   include: user.yml
   tags: st2, user

--- a/roles/st2/tasks/version.yml
+++ b/roles/st2/tasks/version.yml
@@ -1,0 +1,15 @@
+---
+# Getting the current st2 version is required to understand which 'st2_services' to restart
+- name: Get installed st2 version
+  command: /opt/stackstorm/st2/bin/python -c 'import st2common; print st2common.__version__'
+  changed_when: no
+  check_mode: no
+  register: _st2_version_installed
+  when: _st2_version_installed is not defined
+
+# Injecting 'st2_services' var in the middle of play verified to work with 'restart st2' handler as handlers flushed as last step
+- name: Redefine list of services based on st2 version
+  set_fact:
+    st2_services: "{{ st2_services }} + {{ item.value }}"
+  with_dict: "{{ st2_services_versioned }}"
+  when: item.key is version(st2_version_installed, '<=')

--- a/roles/st2/vars/main.yml
+++ b/roles/st2/vars/main.yml
@@ -15,11 +15,11 @@ st2_services:
 
 # List of additional stackstorm services associated with specific st2 version release
 st2_services_versioned:
-  2.8.0:
+  2.8:
     - st2workflowengine
-  2.9.0:
+  2.9:
     - st2timersengine
-  3.0.0:
+  3.0:
     - st2scheduler
 
 # Placeholder for st2 installed version, determined during run

--- a/roles/st2/vars/main.yml
+++ b/roles/st2/vars/main.yml
@@ -12,8 +12,18 @@ st2_services:
   - st2api
   - st2stream
   - st2auth
-  - st2workflowengine
-  - st2timersengine
+
+# List of additional stackstorm services associated with specific st2 version release
+st2_services_versioned:
+  2.8.0:
+    - st2workflowengine
+  2.9.0:
+    - st2timersengine
+  3.0.0:
+    - st2scheduler
+
+# Placeholder for st2 installed version, determined during run
+st2_version_installed: "{{ _st2_version_installed.stdout }}"
 
 # Where to store the ST2 datastore encryption key (automatically generated during install)
 st2_datastore_key_file: /etc/st2/keys/datastore_key.json


### PR DESCRIPTION
Closes #207 

This PR adds new service `st2scheduler`, introduced since StackStorm `v3.0`.

This time as absence of the new service fails the build, need to implement version-dependent logic (originally proposed by @cognifloyd) when specific services are selected depending on installed StackStorm version.
