### PR TITLE
Use older 'version_compare' jinja test, compatible with Ansible before v2.5.0

### DIFF
--- a/roles/st2/tasks/version.yml
+++ b/roles/st2/tasks/version.yml
@@ -12,4 +12,4 @@
   set_fact:
     st2_services: "{{ st2_services }} + {{ item.value }}"
   with_dict: "{{ st2_services_versioned }}"
-  when: item.key is version(st2_version_installed, '<=')
+  when: item.key is version_compare(st2_version_installed, '<=')


### PR DESCRIPTION
The current state of Ansible-st2 plays is that they're compatible (tested) with Ansible `v2.3.0`, except of this tiny test https://docs.ansible.com/ansible/2.5/user_guide/playbooks_tests.html#version-comparison

This PR makes sense to release latest `v2.3.0`-compatible play via `v0.8.9` before bumping min Ansible to `v2.5.0` as part of #190 and `v0.9.0` release.
