### PR TITLE
Fix 'get installed st2 version' task not being run properly in some Ansible versions

### DIFF
--- a/roles/st2/tasks/version.yml
+++ b/roles/st2/tasks/version.yml
@@ -5,7 +5,6 @@
   changed_when: no
   check_mode: no
   register: _st2_version_installed
-  when: _st2_version_installed is not defined
 
 # Injecting 'st2_services' var in the middle of play verified to work with 'restart st2' handler as handlers flushed as last step
 - name: Redefine list of services based on st2 version


### PR DESCRIPTION
As seen in `ansible-pull` environment, version `2.5.10`.

```
TASK [st2 : Redefine list of services based on st2 version] ********************
fatal: [slack-relay001.uswest2.stackstorm.net]: FAILED! => {"msg": "The conditional check 'item.key is version_compare(st2_version_installed, '<=')' failed. The error was: error while evaluating conditional (item.key is version_compare(st2_version_installed, '<=')): 'dict object' has no attribute 'stdout'\n\nThe error appears to have been in '/etc/ansible/roles/StackStorm.stackstorm/roles/st2/tasks/version.yml': line 11, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# Injecting 'st2_services' var in the middle of play verified to work with 'restart st2' handler as handlers flushed as last step\n- name: Redefine list of services based on st2 version\n  ^ here\n"}
```
while this is executed correctly in newer versions.


After checking the play run, the task is skipped due to `when` conditional.
Could be how Ansible handles var `register` vs `when` in different Ansible versions.