### PR TITLE
Mongo Auth | Intall pymongo via pip (vs via sys pkgs)

### DIFF
--- a/roles/StackStorm.mongodb/tasks/mongodb_auth.yml
+++ b/roles/StackStorm.mongodb/tasks/mongodb_auth.yml
@@ -7,8 +7,9 @@
   tags: [databases, mongodb]
 
 - name: Install pymongo (for the mongodb_user module)
-  # pymongo 3.2+ is required to work with mongo 3.2+. system packages are too old.
+  # Use pip because system packages are too old for adequate mongodb support.
+  # https://docs.mongodb.com/ecosystem/drivers/driver-compatibility-reference/#python-driver-compatibility
   become: yes
   pip:
-    name: "pymongo=={{ mongodb_major_minor_version }}"
+    name: "pymongo>=3.10.1,<4.0.0"
   tags: [databases, mongodb]

--- a/roles/StackStorm.mongodb/tasks/mongodb_auth.yml
+++ b/roles/StackStorm.mongodb/tasks/mongodb_auth.yml
@@ -1,6 +1,14 @@
 ---
-- name: Ensure pymongo is installed for the mongodb_user ansible module
+- name: Install pip (for the installation of pymongo)
   become: yes
   package:
-    name: python-pymongo
+    name: python-pip
     state: present
+  tags: [databases, mongodb]
+
+- name: Install pymongo (for the mongodb_user module)
+  # pymongo 3.2+ is required to work with mongo 3.2+. system packages are too old.
+  become: yes
+  pip:
+    name: "pymongo=={{ mongodb_major_minor_version }}"
+  tags: [databases, mongodb]


### PR DESCRIPTION
This PR is preparation for enabling mongo auth via the ansible playbook.
These tasks will not be activated until all required tasks are committed.

This installs pip via system package, and then pymongo via pip.

pymongo is needed for mongodb_user module to enable mongo auth.
pymongo 3.2+ is required to work with mongo 3.2+
system packages are too old on all but Ubuntu 16:
 - 2.5.2 on EL 6 and EL 7
 - 2.6.3 on Ubuntu 14 Trusty
 - 3.2 on Ubuntu 16 Xenial