### PR TITLE
Update stable repo keys

### DIFF
--- a/roles/bwc/vars/enterprise.yml
+++ b/roles/bwc/vars/enterprise.yml
@@ -1,2 +1,2 @@
 ---
-enterprise_key_id: C2E73424D59097AB
+enterprise_key_id: E8518D3790C81C76

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: "Including stable node version"
-  include_vars:
-    file: "stable.yml"
-  when: (st2repo_name == "stable")
-
 - name: Install nodejs on {{ ansible_distribution }}
   include: nodejs_{{ ansible_pkg_mgr }}.yml
   tags: nodejs

--- a/roles/nodejs/vars/stable.yml
+++ b/roles/nodejs/vars/stable.yml
@@ -1,2 +1,0 @@
----
-nodejs_major_version: "6"

--- a/roles/st2repo/vars/stable.yml
+++ b/roles/st2repo/vars/stable.yml
@@ -1,2 +1,2 @@
 ---
-key_id: C2E73424D59097AB
+key_id: 3CE01873543A4CCE


### PR DESCRIPTION
This PR updates the stable repository public key IDs for the
enterprise and stable repos in packagecloud. This is a required change
following packagecloud GPG changes.