### PR TITLE
New linting rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,4 +18,4 @@ jobs:
       - run:
           name: Ansible-lint check
           command: |
-            ansible-lint -v roles/*/*/*.yaml roles/*/*/*.yml stackstorm.yml
+            ansible-lint -x 204 -v roles/*/*/*.yml stackstorm.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,4 +18,4 @@ jobs:
       - run:
           name: Ansible-lint check
           command: |
-            ansible-lint -x 204 -v roles/*/*/*.yml stackstorm.yml
+            ansible-lint -x 204 -v roles/*/*/*.yaml roles/*/*/*.yml stackstorm.yml

--- a/roles/bwc/meta/main.yml
+++ b/roles/bwc/meta/main.yml
@@ -14,12 +14,10 @@ galaxy_info:
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - stackstorm
-    - BWC
-    - Brocade Workflow Composer
-    - EWC
-    - Extreme Workflow Composer
+    - bwc
+    - ewc
     - repositories
     - packagecloud
   dependencies:

--- a/roles/bwc/tasks/bwc_repos_setup.yml
+++ b/roles/bwc/tasks/bwc_repos_setup.yml
@@ -63,4 +63,4 @@
     - ewc
     - enterprise
   register: bwc_repo_added
-  when: bwc_read_token != ''
+  when: bwc_read_token

--- a/roles/bwc/tasks/bwc_repos_setup.yml
+++ b/roles/bwc/tasks/bwc_repos_setup.yml
@@ -63,4 +63,4 @@
     - ewc
     - enterprise
   register: bwc_repo_added
-  when: bwc_read_token
+  when: bwc_read_token | length > 0

--- a/roles/bwc_smoketests/meta/main.yml
+++ b/roles/bwc_smoketests/meta/main.yml
@@ -14,12 +14,10 @@ galaxy_info:
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - stackstorm
-    - BWC
-    - Brocade Workflow Composer
-    - EWC
-    - Extreme Workflow Composer
+    - bwc
+    - ewc
     - repositories
     - packagecloud
   dependencies:

--- a/roles/epel/meta/main.yml
+++ b/roles/epel/meta/main.yml
@@ -10,5 +10,5 @@ galaxy_info:
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - system

--- a/roles/mongodb/meta/main.yml
+++ b/roles/mongodb/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - system
 dependencies:
   - role: epel

--- a/roles/nginx/meta/main.yml
+++ b/roles/nginx/meta/main.yml
@@ -15,6 +15,6 @@ galaxy_info:
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - web
     - nginx

--- a/roles/nodejs/meta/main.yml
+++ b/roles/nodejs/meta/main.yml
@@ -15,5 +15,5 @@ galaxy_info:
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - system

--- a/roles/postgresql/meta/main.yml
+++ b/roles/postgresql/meta/main.yml
@@ -15,5 +15,5 @@ galaxy_info:
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - system

--- a/roles/rabbitmq/meta/main.yml
+++ b/roles/rabbitmq/meta/main.yml
@@ -14,5 +14,5 @@ galaxy_info:
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - system

--- a/roles/st2/meta/main.yml
+++ b/roles/st2/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - stackstorm
     - st2
     - automation

--- a/roles/st2/tasks/proxy.yml
+++ b/roles/st2/tasks/proxy.yml
@@ -6,7 +6,7 @@
     dest: /etc/{{ 'default' if ansible_facts.pkg_mgr == 'apt' else 'sysconfig' }}/{{ item.0 }}
     create: yes
     regexp: '^{{ item.1 }}='
-    line: "{{ item.1}}={{ ansible_facts.env.get(item.1) }}"
+    line: "{{ item.1 }}={{ ansible_facts.env.get(item.1) }}"
     # NB: Empty ENV var cast to 'None' string in Ansible
     state: "{{ 'present' if ansible_facts.env.get(item.1, 'None') != 'None' else 'absent' }}"
   vars:

--- a/roles/st2chatops/meta/main.yml
+++ b/roles/st2chatops/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - st2
     - devops
     - chatops

--- a/roles/st2chatops/tasks/main.yml
+++ b/roles/st2chatops/tasks/main.yml
@@ -82,7 +82,7 @@
 
 - name: Generate authentication token
   command: st2 auth "{{ st2_auth_username }}" -p "{{ st2_auth_password }}" -t
-  when: task_apikey_not_exists is succeeded and task_user_st2_api_key.changed == false
+  when: task_apikey_not_exists is succeeded and task_user_st2_api_key.changed
   register: task_st2_token
   tags: [st2chatops, skip_ansible_lint]
 

--- a/roles/st2chatops/tasks/main.yml
+++ b/roles/st2chatops/tasks/main.yml
@@ -82,7 +82,7 @@
 
 - name: Generate authentication token
   command: st2 auth "{{ st2_auth_username }}" -p "{{ st2_auth_password }}" -t
-  when: task_apikey_not_exists is succeeded and task_user_st2_api_key.changed
+  when: task_apikey_not_exists is succeeded and task_user_st2_api_key is not changed
   register: task_st2_token
   tags: [st2chatops, skip_ansible_lint]
 

--- a/roles/st2mistral/meta/main.yml
+++ b/roles/st2mistral/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - automation
     - devops
     - workflows

--- a/roles/st2repo/meta/main.yml
+++ b/roles/st2repo/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - stackstorm
     - repositories
     - packagecloud

--- a/roles/st2web/meta/main.yml
+++ b/roles/st2web/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
       versions:
         - 6
         - 7
-  categories:
+  galaxy_tags:
     - system
 dependencies:
   - role: nginx


### PR DESCRIPTION
`ansible-lint` 4.0.0 introduces many new default rules. These trip us up in many places. 

The only new default rule I have not fixed is the 120-char line length rule. For now I have just excluded that rule from checks.

I have also fixed a small issue with our CircleCi config, where it was running ansible-lint against non-existent `*.yaml` files.