### PR TITLE
Use yum_repository for nodesource repo install

### DIFF
--- a/roles/StackStorm.nodejs/tasks/nodejs_yum.yml
+++ b/roles/StackStorm.nodejs/tasks/nodejs_yum.yml
@@ -16,6 +16,7 @@
   yum:
     name: "nodesource-release-el{{ ansible_facts.distribution_major_version }}-1.noarch"
     state: absent
+  register: nodesource_repo_rm
   tags: nodejs
 
 - name: Add nodesource repo file
@@ -33,7 +34,7 @@
     gpgcheck: yes
     gpgkey: file:///etc/pki/rpm-gpg/NODESOURCE-GPG-SIGNING-KEY-EL
     state: present
-  register: nodesource_repo
+  register: nodesource_repo_add
   tags: nodejs
 
 - name: Install nodejs
@@ -44,7 +45,7 @@
     # TODO: Allow yum downgrade since Ansible 2.4
     # https://github.com/ansible/ansible/pull/21516
     # allow_downgrade: yes
-    update_cache: "{{ nodesource_repo is changed }}"
+    update_cache: "{{ nodesource_repo_rm is changed or nodesource_repo_add is changed }}"
   register: _task
   retries: 5
   delay: 3

--- a/roles/StackStorm.nodejs/tasks/nodejs_yum.yml
+++ b/roles/StackStorm.nodejs/tasks/nodejs_yum.yml
@@ -10,28 +10,20 @@
   until: _task is succeeded
   tags: nodejs
 
-# nodesource updates the baseurl (which includes the major nodejs version)
-# in their yum repo release rpm without increasing the rpm's version number.
-# So we must manually remove the repo to get yum to add the correct release.
-- name: Determine if nodesource repo upgrade is required (ie when updating nodejs major version)
-  shell: "grep -q pub_{{ nodejs_major_version }}.x /etc/yum.repos.d/nodesource-*.repo"
-  changed_when: no
-  failed_when: no
-  register: nodesource_repo_check
-
-- name: Remove old nodesource repo on upgrade
-  when: nodesource_repo_check.rc != 0
-  become: yes
-  yum:
-    name: "nodesource-release-el{{ ansible_facts.distribution_major_version }}-1.noarch"
-    state: absent
-  register: rm_nodesource_repo
-  tags: nodejs
-
 - name: Add nodesource repo
   become: yes
-  yum:
-    name: "http://rpm.nodesource.com/pub_{{ nodejs_major_version }}.x/el/{{ ansible_facts.distribution_major_version }}/{{ ansible_facts.architecture }}/nodesource-release-el{{ ansible_facts.distribution_major_version }}-1.noarch.rpm"
+  # This is based on the nodesource repo rpm (both 4.x and 10.x for EL6/7/8),
+  # but that rpm is not versioned even though it hard-codes the major node.js version.
+  # So, installing the repo directly (vs via the rpm) simplifies major node.js upgrades.
+  # see - http://rpm.nodesource.com/pub_10.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
+  yum_repository:
+    file: "nodesource-el{{ ansible_facts.distribution_major_version }}"
+    name: nodesource
+    description: "Node.js Packages for Enterprise Linux {{ ansible_facts.distribution_major_version }} - $basearch"
+    baseurl: https://rpm.nodesource.com/pub_{{ nodejs_major_version }}.x/el/{{ ansible_facts.distribution_major_version }}/$basearch
+    failovermethod: priority
+    gpgcheck: yes
+    gpgkey: http://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
     state: present
   tags: nodejs
 

--- a/roles/StackStorm.nodejs/tasks/nodejs_yum.yml
+++ b/roles/StackStorm.nodejs/tasks/nodejs_yum.yml
@@ -23,7 +23,7 @@
     baseurl: https://rpm.nodesource.com/pub_{{ nodejs_major_version }}.x/el/{{ ansible_facts.distribution_major_version }}/$basearch
     failovermethod: priority
     gpgcheck: yes
-    gpgkey: http://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
+    gpgkey: file:///etc/pki/rpm-gpg/NODESOURCE-GPG-SIGNING-KEY-EL
     state: present
   register: nodesource_repo
   tags: nodejs

--- a/roles/StackStorm.nodejs/tasks/nodejs_yum.yml
+++ b/roles/StackStorm.nodejs/tasks/nodejs_yum.yml
@@ -10,6 +10,24 @@
   until: _task is succeeded
   tags: nodejs
 
+# nodesource updates the baseurl (which includes the major nodejs version)
+# in their yum repo release rpm without increasing the rpm's version number.
+# So we must manually remove the repo to get yum to add the correct release.
+- name: Determine if nodesource repo upgrade is required (ie when updating nodejs major version)
+  shell: "grep -q pub_{{ nodejs_major_version }}.x /etc/yum.repos.d/nodesource-*.repo"
+  changed_when: no
+  failed_when: no
+  register: nodesource_repo_check
+
+- name: Remove old nodesource repo on upgrade
+  when: nodesource_repo_check.rc != 0
+  become: yes
+  yum:
+    name: "nodesource-release-el{{ ansible_facts.distribution_major_version }}-1.noarch"
+    state: absent
+  register: rm_nodesource_repo
+  tags: nodejs
+
 - name: Add nodesource repo
   become: yes
   yum:
@@ -25,6 +43,7 @@
     # TODO: Allow yum downgrade since Ansible 2.4
     # https://github.com/ansible/ansible/pull/21516
     # allow_downgrade: yes
+    update_cache: "{{ rm_nodesource_repo is changed }}"
   register: _task
   retries: 5
   delay: 3

--- a/roles/StackStorm.nodejs/tasks/nodejs_yum.yml
+++ b/roles/StackStorm.nodejs/tasks/nodejs_yum.yml
@@ -10,7 +10,15 @@
   until: _task is succeeded
   tags: nodejs
 
-- name: Add nodesource repo
+- name: Remove nodesource repo rpm
+  # rpm conflicts with yum_repository added file below
+  become: yes
+  yum:
+    name: "nodesource-release-el{{ ansible_facts.distribution_major_version }}-1.noarch"
+    state: absent
+  tags: nodejs
+
+- name: Add nodesource repo file
   become: yes
   # This is based on the nodesource repo rpm (both 4.x and 10.x for EL6/7/8),
   # but that rpm is not versioned even though it hard-codes the major node.js version.

--- a/roles/StackStorm.nodejs/tasks/nodejs_yum.yml
+++ b/roles/StackStorm.nodejs/tasks/nodejs_yum.yml
@@ -25,6 +25,7 @@
     gpgcheck: yes
     gpgkey: http://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
     state: present
+  register: nodesource_repo
   tags: nodejs
 
 - name: Install nodejs
@@ -35,7 +36,7 @@
     # TODO: Allow yum downgrade since Ansible 2.4
     # https://github.com/ansible/ansible/pull/21516
     # allow_downgrade: yes
-    update_cache: "{{ rm_nodesource_repo is changed }}"
+    update_cache: "{{ nodesource_repo is changed }}"
   register: _task
   retries: 5
   delay: 3


### PR DESCRIPTION
Add some tasks to ensure the nodesource repo is up-to-date before attempting to install nodejs.
Thus, if this playbook is run against a machine that already has the repo, it will safely upgrade
the repo so that the nodejs install task doesn't complain about not finding the version requested.

This also sets update_cache on upgrade so that the newer nodejs rpm becomes available for install.