### PR TITLE
Add YAML lint checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
-# CircleCI is used only for Ansible-Lint and Ansible Syntax checks
+# CircleCI is used only for linter and syntax checks
 version: 2
 jobs:
-  build:
+  # Run Ansible-lint checks
+  ansible-lint:
     docker:
       - image: williamyeh/ansible:ubuntu16.04
     steps:
@@ -19,3 +20,26 @@ jobs:
           name: Ansible-lint check
           command: |
             ansible-lint -x 204 -v roles/*/*/*.yaml roles/*/*/*.yml stackstorm.yml
+
+  # Run YAML lint checks
+  yaml-lint:
+    docker:
+      - image: sdesbure/yamllint
+    steps:
+      - checkout
+      - run:
+          name: YAML lint checks
+          command: yamllint .
+
+workflows:
+  version: 2
+  helm:
+    jobs:
+      - ansible-lint
+      - yaml-lint
+
+experimental:
+  notify:
+    branches:
+      only:
+        - master

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,7 +17,7 @@ provisioner:
   extra_vars:
     st2repo_name: <%= ENV['ST2_REPO'] || 'stable' %>
     ewc_repo: <%= ENV['EWC_REPO'] || 'enterprise' %>
-    ewc_license: <%= ENV['LICENSE'] ? ENV[ENV['LICENSE']] : ENV['BWC_LICENSE_ENTERPRISE'] %>
+    ewc_license: "<%= ENV['LICENSE'] ? ENV[ENV['LICENSE']] : ENV['BWC_LICENSE_ENTERPRISE'] %>"
     st2chatops_hubot_adapter: slack
     st2chatops_config:
       HUBOT_SLACK_TOKEN: <%= ENV['HUBOT_SLACK_TOKEN'] %>

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,20 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces: {max-spaces-inside: 1, level: error}
+  brackets: {max-spaces-inside: 1, level: error}
+  colons: {max-spaces-after: -1, level: error}
+  commas: {max-spaces-after: -1, level: error}
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines: {max: 3, level: error}
+  hyphens: {level: error}
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: {type: unix}
+  trailing-spaces: disable

--- a/.yamllint
+++ b/.yamllint
@@ -18,3 +18,4 @@ rules:
   new-line-at-end-of-file: disable
   new-lines: {type: unix}
   trailing-spaces: disable
+  truthy: disable

--- a/roles/postgresql/tasks/postgresql_yum6.yml
+++ b/roles/postgresql/tasks/postgresql_yum6.yml
@@ -77,4 +77,3 @@
     state: started
     enabled: yes
   tags: [db, postgresql]
-

--- a/roles/st2/tasks/datastore.yml
+++ b/roles/st2/tasks/datastore.yml
@@ -30,4 +30,3 @@
     option: encryption_key_path
     value: "{{ st2_datastore_key_file }}"
   notify: restart st2api
-


### PR DESCRIPTION
YAML lint check is now recommended as Ansible Galaxy roles are scored based on set of automated verifications.

* https://galaxy.ansible.com/docs/contributing/content_scoring.html  - rules
* https://galaxy.ansible.com/StackStorm/stackstorm - where StackStorm roles are evaluated

This should fix the StackStorm role rating at Ansible Galaxy.