### PR TITLE
Add Ansible Galaxy 'system' tag

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
         - 6
         - 7
   categories:
+    - system
     - ops
     - devops
     - chatops

--- a/roles/ewc/meta/main.yml
+++ b/roles/ewc/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
         - 6
         - 7
   galaxy_tags:
+    - system
     - stackstorm
     - bwc
     - ewc

--- a/roles/st2/meta/main.yml
+++ b/roles/st2/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
         - 6
         - 7
   galaxy_tags:
+    - system
     - stackstorm
     - st2
     - automation

--- a/roles/st2chatops/meta/main.yml
+++ b/roles/st2chatops/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
         - 6
         - 7
   galaxy_tags:
+    - system
     - st2
     - devops
     - chatops

--- a/roles/st2mistral/meta/main.yml
+++ b/roles/st2mistral/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
         - 6
         - 7
   galaxy_tags:
+    - system
     - automation
     - devops
     - workflows

--- a/roles/st2repo/meta/main.yml
+++ b/roles/st2repo/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
         - 6
         - 7
   galaxy_tags:
+    - system
     - stackstorm
     - repositories
     - packagecloud


### PR DESCRIPTION
Cosmetic change that adds `system` tag to the list of Galaxy tags to make sure StackStorm role is present within one of the features categories at https://galaxy.ansible.com/home