### PR TITLE
Bump minimum Ansible version to 2.5 in Galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
   author: armab
   company: StackStorm
   license: Apache 2.0
-  min_ansible_version: 2.3
+  min_ansible_version: 2.5
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
A missing cosmetic change that bumps minimum Ansible version to `v2.5` to show correctly in Galaxy: https://galaxy.ansible.com/StackStorm/stackstorm
