### PR TITLE
Fix ansible-lint CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
 
 workflows:
   version: 2
-  helm:
+  lint:
     jobs:
       - ansible-lint
       - yaml-lint

--- a/roles/StackStorm.ewc/tasks/ewc_repos_apt.yml
+++ b/roles/StackStorm.ewc/tasks/ewc_repos_apt.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install prereqs (Debian)
   become: yes
   apt:

--- a/roles/StackStorm.ewc/tasks/ewc_repos_cleanup_apt.yml
+++ b/roles/StackStorm.ewc/tasks/ewc_repos_cleanup_apt.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Cleanup repo list file from disk
   become: yes
   file:

--- a/roles/StackStorm.ewc/tasks/ewc_repos_cleanup_yum.yml
+++ b/roles/StackStorm.ewc/tasks/ewc_repos_cleanup_yum.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Cleanup repo list file from disk
   become: yes
   yum_resository:

--- a/roles/StackStorm.ewc/tasks/ewc_repos_cleanup_yum.yml
+++ b/roles/StackStorm.ewc/tasks/ewc_repos_cleanup_yum.yml
@@ -1,7 +1,7 @@
 ---
 - name: Cleanup repo list file from disk
   become: yes
-  yum_resository:
+  yum_repository:
     name: "StackStorm_{{ ewc_repo }}"
     state: absent
   tags:

--- a/roles/StackStorm.ewc/tasks/ewc_repos_yum.yml
+++ b/roles/StackStorm.ewc/tasks/ewc_repos_yum.yml
@@ -1,5 +1,4 @@
 ---
-
 # Fixes "Failure talking to yum: Cannot retrieve repository metadata (repomd.xml) for repository: StackStorm_stable. Please verify its path and try again" when installing st2
 - name: Update ca-certificates package
   become: yes

--- a/roles/StackStorm.ewc/tasks/ldap.yml
+++ b/roles/StackStorm.ewc/tasks/ldap.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Setup st2.conf auth backend to LDAP
   become: yes
   # Unfortunately, ``with_dict`` also logs the dict which could leak passwords.

--- a/roles/StackStorm.ewc/tasks/license.yml
+++ b/roles/StackStorm.ewc/tasks/license.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Check if EWC license hash file is present
   stat:
     path: /etc/packagecloud/ewc_license_hash.txt

--- a/roles/StackStorm.ewc/tasks/rbac.yml
+++ b/roles/StackStorm.ewc/tasks/rbac.yml
@@ -1,59 +1,59 @@
 ---
-  - name: Copy default RBAC roles to /opt/stackstorm/rbac/roles directory
-    become: yes
-    template:
-      src: rbac_roles/roles.yml.j2
-      dest: /opt/stackstorm/rbac/roles/{{ item.name }}.yaml
-      owner: st2
-      group: st2
-    loop: "{{ ewc_rbac_default_roles }}"
-    notify:
-      - reload ewc_rbac
+- name: Copy default RBAC roles to /opt/stackstorm/rbac/roles directory
+  become: yes
+  template:
+    src: rbac_roles/roles.yml.j2
+    dest: /opt/stackstorm/rbac/roles/{{ item.name }}.yaml
+    owner: st2
+    group: st2
+  loop: "{{ ewc_rbac_default_roles }}"
+  notify:
+    - reload ewc_rbac
 
-  - name: Copy user defined RBAC roles to /opt/stackstorm/rbac/roles directory
-    become: yes
-    template:
-      src: rbac_roles/roles.yml.j2
-      dest: /opt/stackstorm/rbac/roles/{{ item.name }}.yaml
-      owner: st2
-      group: st2
-    loop: "{{ ewc_rbac.roles }}"
-    when: ewc_rbac.roles is defined
-    notify:
-      - reload ewc_rbac
+- name: Copy user defined RBAC roles to /opt/stackstorm/rbac/roles directory
+  become: yes
+  template:
+    src: rbac_roles/roles.yml.j2
+    dest: /opt/stackstorm/rbac/roles/{{ item.name }}.yaml
+    owner: st2
+    group: st2
+  loop: "{{ ewc_rbac.roles }}"
+  when: ewc_rbac.roles is defined
+  notify:
+    - reload ewc_rbac
 
-  - name: Copy default RBAC assignments to /opt/stackstorm/rbac/assignments directory
-    become: yes
-    template:
-      src: rbac_assignments/assignments.yml.j2
-      dest: /opt/stackstorm/rbac/assignments/{{ item.name }}.yaml
-      owner: st2
-      group: st2
-    loop: "{{ ewc_rbac_default_assignments }}"
-    notify:
-      - reload ewc_rbac
+- name: Copy default RBAC assignments to /opt/stackstorm/rbac/assignments directory
+  become: yes
+  template:
+    src: rbac_assignments/assignments.yml.j2
+    dest: /opt/stackstorm/rbac/assignments/{{ item.name }}.yaml
+    owner: st2
+    group: st2
+  loop: "{{ ewc_rbac_default_assignments }}"
+  notify:
+    - reload ewc_rbac
 
-  - name: Copy user defined RBAC assignments to /opt/stackstorm/rbac/assignments directory
-    become: yes
-    template:
-      src: rbac_assignments/assignments.yml.j2
-      dest: /opt/stackstorm/rbac/assignments/{{ item.name }}.yaml
-      owner: st2
-      group: st2
-    loop: "{{ ewc_rbac.assignments }}"
-    when: ewc_rbac.assignments is defined
-    notify:
-      - reload ewc_rbac
+- name: Copy user defined RBAC assignments to /opt/stackstorm/rbac/assignments directory
+  become: yes
+  template:
+    src: rbac_assignments/assignments.yml.j2
+    dest: /opt/stackstorm/rbac/assignments/{{ item.name }}.yaml
+    owner: st2
+    group: st2
+  loop: "{{ ewc_rbac.assignments }}"
+  when: ewc_rbac.assignments is defined
+  notify:
+    - reload ewc_rbac
 
-  - name: Enable RBAC in st2 configuration
-    become: yes
-    ini_file:
-      dest: /etc/st2/st2.conf
-      section: rbac
-      option: enable
-      value: True
-      backup: yes
-    notify:
-      - restart st2
-      - reload ewc_rbac
-      - restart st2api
+- name: Enable RBAC in st2 configuration
+  become: yes
+  ini_file:
+    dest: /etc/st2/st2.conf
+    section: rbac
+    option: enable
+    value: True
+    backup: yes
+  notify:
+    - restart st2
+    - reload ewc_rbac
+    - restart st2api

--- a/roles/StackStorm.nginx/tasks/nginx_yum.yml
+++ b/roles/StackStorm.nginx/tasks/nginx_yum.yml
@@ -56,7 +56,7 @@
   setup:
     filter: ansible_selinux
   when: nginx_selinux_dependencies.changed
-  tags: nginx
+  tags: nginx, skip_ansible_lint
 
 - name: Adjust SELinux to allow network access for nginx
   become: yes

--- a/roles/StackStorm.postgresql/tasks/postgresql_yum6.yml
+++ b/roles/StackStorm.postgresql/tasks/postgresql_yum6.yml
@@ -52,7 +52,7 @@
   become: yes
   command: service postgresql-9.4 initdb
   when: install_postgresql.changed
-  tags: [db, postgresql]
+  tags: [db, postgresql, skip_ansible_lint]
 
 - name: yum | MD5-encrypted password for PostgreSQL 1
   become: yes

--- a/roles/StackStorm.postgresql/tasks/postgresql_yum7.yml
+++ b/roles/StackStorm.postgresql/tasks/postgresql_yum7.yml
@@ -17,7 +17,7 @@
   become: yes
   command: postgresql-setup initdb
   when: install_postgresql.changed
-  tags: [db, postgresql]
+  tags: [db, postgresql, skip_ansible_lint]
 
 - name: yum | MD5-encrypted password for PostgreSQL 1
   become: yes

--- a/roles/StackStorm.st2smoketests/tasks/st2chatops.yml
+++ b/roles/StackStorm.st2smoketests/tasks/st2chatops.yml
@@ -1,9 +1,10 @@
 ---
 - name: Verify st2chatops using bin/hubot
   # when editing, make sure it works for at least 2 adapters: 'shell' and 'slack'
-  shell: timeout 10 bash -c '(sleep 5; echo exit ) | bin/hubot'
+  shell: set -o pipefail && timeout 10 bash -c '(sleep 5; echo exit ) | bin/hubot'
   args:
     chdir: /opt/stackstorm/chatops/
+    executable: /bin/bash
   environment:
     HUBOT_LOG_LEVEL: debug
   register: hubot_output


### PR DESCRIPTION
`ansible-lint` recently introduced a few more checks which made our CI to fail.
Update the code to rely on linter updates.
