### PR TITLE
Fix TravisCI failures for forked builds (contributions)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ env:
   - DISTRO=centos-7 ST2_REPO=unstable EWC_REPO=enterprise-unstable LICENSE='BWC_LICENSE_ENTERPRISE_UNSTABLE'
 
 before_script:
-  - echo $TRAVIS_SECURE_ENV_VARS
-  - echo $TRAVIS_PULL_REQUEST_SLUG
-  - echo $TRAVIS_REPO_SLUG
   # Personal token for forked PRs
   - true && `base64 --decode <<< ZXhwb3J0IEhVQk9UX1NMQUNLX1RPS0VOPXhveGItMTc2OTM1OTkzNDE0LWltdFNJRktPYXkxVlFFTWtUdVJWYmh0bAo=`
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ env:
   - DISTRO=centos-7 ST2_REPO=unstable EWC_REPO=enterprise-unstable LICENSE='BWC_LICENSE_ENTERPRISE_UNSTABLE'
 
 before_script:
+  - echo $TRAVIS_SECURE_ENV_VARS
+  - echo $TRAVIS_PULL_REQUEST_SLUG
+  - echo $TRAVIS_REPO_SLUG
   # Personal token for forked PRs
   - true && `base64 --decode <<< ZXhwb3J0IEhVQk9UX1NMQUNLX1RPS0VOPXhveGItMTc2OTM1OTkzNDE0LWltdFNJRktPYXkxVlFFTWtUdVJWYmh0bAo=`
 

--- a/stackstorm.yml
+++ b/stackstorm.yml
@@ -14,6 +14,6 @@
     - StackStorm.st2chatops
     - StackStorm.st2smoketests
     - role: StackStorm.ewc
-      when: ewc_license is defined and ewc_license is not none
+      when: ewc_license is defined and ewc_license | length > 0
     - role: StackStorm.ewc_smoketests
-      when: ewc_license is defined and ewc_license is not none
+      when: ewc_license is defined and ewc_license | length > 0


### PR DESCRIPTION
Fix CI failures for forked builds.
TravisCI changed behavior and stopped sharing secrets with forked CI environments.

This PR excludes Enterprise builds for community contributions.