### PR TITLE
Fix an issue with st2api not being restarted after installing bwc-enterprise package, fix services which are restarted when configuring ldap backend in st2.conf

### DIFF
--- a/roles/StackStorm.ewc/tasks/ldap.yml
+++ b/roles/StackStorm.ewc/tasks/ldap.yml
@@ -12,8 +12,7 @@
   # Don't even setup LDAP if backend_kwargs is not defined
   when: ewc_ldap.backend_kwargs is defined and ewc_ldap.backend_kwargs|length > 0
   notify:
-    - restart st2api
-    - restart st2stream
+    - restart st2auth
 
 - name: Setup st2.conf auth backend_kwargs for LDAP
   become: yes
@@ -28,5 +27,4 @@
   # Don't even setup LDAP if backend_kwargs is not defined
   when: ewc_ldap.backend_kwargs is defined and ewc_ldap.backend_kwargs|length > 0
   notify:
-    - restart st2api
-    - restart st2stream
+    - restart st2auth

--- a/roles/StackStorm.ewc/tasks/main.yml
+++ b/roles/StackStorm.ewc/tasks/main.yml
@@ -24,6 +24,8 @@
     - ewc
     - st2 enterprise
     - skip_ansible_lint
+  notify:
+    - restart st2api
 
 - name: Install present bwc-enterprise package, no auto-update
   become: yes
@@ -38,6 +40,8 @@
   tags:
     - ewc
     - st2 enterprise
+  notify:
+    - restart st2api
 
 - name: Install pinned bwc-enterprise package
   become: yes
@@ -54,6 +58,8 @@
   tags:
     - ewc
     - st2 enterprise
+  notify:
+    - restart st2api
 
 - name: Setup RBAC and setup roles and assignments if ewc_rbac is defined
   import_tasks: rbac.yml

--- a/roles/StackStorm.ewc/tasks/main.yml
+++ b/roles/StackStorm.ewc/tasks/main.yml
@@ -26,6 +26,7 @@
     - skip_ansible_lint
   notify:
     - restart st2api
+    - restart st2auth
 
 - name: Install present bwc-enterprise package, no auto-update
   become: yes
@@ -42,6 +43,7 @@
     - st2 enterprise
   notify:
     - restart st2api
+    - restart st2auth
 
 - name: Install pinned bwc-enterprise package
   become: yes
@@ -60,6 +62,7 @@
     - st2 enterprise
   notify:
     - restart st2api
+    - restart st2auth
 
 - name: Setup RBAC and setup roles and assignments if ewc_rbac is defined
   import_tasks: rbac.yml

--- a/roles/StackStorm.ewc/tasks/rbac.yml
+++ b/roles/StackStorm.ewc/tasks/rbac.yml
@@ -55,6 +55,7 @@
     backup: yes
   notify:
     - restart st2api
+    - reload ewc_rbac
 
 - name: Configure RBAC backend in st2 configuration
   become: yes
@@ -66,3 +67,4 @@
     backup: yes
   notify:
     - restart st2api
+    - reload ewc_rbac

--- a/roles/StackStorm.ewc/tasks/rbac.yml
+++ b/roles/StackStorm.ewc/tasks/rbac.yml
@@ -57,3 +57,16 @@
     - restart st2
     - reload ewc_rbac
     - restart st2api
+
+- name: Configure RBAC backend in st2 configuration
+  become: yes
+  ini_file:
+    dest: /etc/st2/st2.conf
+    section: rbac
+    option: backend
+    value: enterprise
+    backup: yes
+  notify:
+    - restart st2
+    - reload ewc_rbac
+    - restart st2api

--- a/roles/StackStorm.ewc/tasks/rbac.yml
+++ b/roles/StackStorm.ewc/tasks/rbac.yml
@@ -54,8 +54,6 @@
     value: True
     backup: yes
   notify:
-    - restart st2
-    - reload ewc_rbac
     - restart st2api
 
 - name: Configure RBAC backend in st2 configuration
@@ -67,6 +65,4 @@
     value: enterprise
     backup: yes
   notify:
-    - restart st2
-    - reload ewc_rbac
     - restart st2api

--- a/roles/StackStorm.ewc_smoketests/tasks/main.yml
+++ b/roles/StackStorm.ewc_smoketests/tasks/main.yml
@@ -65,7 +65,7 @@
     - ewc-smoke-tests
 
 - name: Test some other action that "{{ ewc_smoke_tests_user }}" cannot run
-  command: st2 run core.http url="https://google.com"
+  command: st2 run core.http url="https://www.google.com"
   environment:
     ST2_AUTH_TOKEN: "{{ st2_token_smoke_tests_user.stdout }}"
   ignore_errors: yes

--- a/roles/StackStorm.st2/handlers/main.yml
+++ b/roles/StackStorm.st2/handlers/main.yml
@@ -15,6 +15,12 @@
     name: st2actionrunner
     state: restarted
 
+- name: restart st2auth
+  become: yes
+  service:
+    name: st2auth
+    state: restarted
+
 - name: restart st2api
   become: yes
   service:


### PR DESCRIPTION
This pull request fixes two issue:

1. Make sure ``st2api`` is restarted after ``bwc-enterprise`` package is installed so RBAC indeed enabled and working (this is needed in StackStorm >= 3.0.0)
2. Restart ``st2auth`` when configuring LDAP backend in st2.conf - previously incorrect services were restarted