### PR TITLE
Ensure st2.conf values are not converted to particular structure

### DIFF
--- a/roles/StackStorm.st2/tasks/config.yml
+++ b/roles/StackStorm.st2/tasks/config.yml
@@ -5,7 +5,7 @@
     dest: /etc/st2/st2.conf
     section: "{{ _conf_section_name }}"
     option: "{{ _conf_option.0 }}"
-    value: "{{ _conf_option.1 }}"
+    value: "{{ _conf_option.1 | string }}"
   # dict2items not available until 2.6, so use Jinja's dictsort instead
   loop: "{{ _conf_options | dictsort }}"
   loop_control:

--- a/roles/StackStorm.st2mistral/tasks/config.yml
+++ b/roles/StackStorm.st2mistral/tasks/config.yml
@@ -5,7 +5,7 @@
     dest: /etc/mistral/mistral.conf
     section: "{{ _conf_section_name }}"
     option: "{{ _conf_option.0 }}"
-    value: "{{ _conf_option.1 }}"
+    value: "{{ _conf_option.1 | string }}"
   # dict2items not available until 2.6, so use Jinja's dictsort instead
   loop: "{{ _conf_options | dictsort }}"
   loop_control:


### PR DESCRIPTION
Closes #238 

Covers edge case when user wants to set in st2.conf json-formatted value which might be converted to particular structure during the jinja/ansible pipeline.

See https://github.com/StackStorm/ansible-st2/issues/156