### PR TITLE
Fix 'ewc_license' conditional check in stackstorm.yml example play

### DIFF
--- a/stackstorm.yml
+++ b/stackstorm.yml
@@ -14,6 +14,6 @@
     - StackStorm.st2chatops
     - StackStorm.st2smoketests
     - role: StackStorm.ewc
-      when: ewc_license is defined and ewc_license | length > 0
+      when: ewc_license is defined and ewc_license is not none and ewc_license | length > 0
     - role: StackStorm.ewc_smoketests
-      when: ewc_license is defined and ewc_license | length > 0
+      when: ewc_license is defined and ewc_license is not none and ewc_license | length > 0


### PR DESCRIPTION
Closes #237 
Under some circumstances `ewc_license` could be `None` in `stackstorm.yml` Ansible play

Fixes:
>fatal: [ubuntu16]: FAILED! => {"msg": "The conditional check 'ewc_license is defined and ewc_license | length > 0' failed. The error was: Unexpected templating type error occurred on ({% if ewc_license is defined and ewc_license | length > 0 %} True {% else %} False {% endif %}): object of type 'NoneType' has no len()\n\n"}

