### PR TITLE
Bring in proxy env vars if defined as Ansible vars

### DIFF
--- a/stackstorm.yml
+++ b/stackstorm.yml
@@ -1,6 +1,7 @@
 ---
 - name: Install st2
   hosts: all
+  environment: "{{ st2_proxy_env | default(None) }}"
   roles:
     - StackStorm.mongodb
     - StackStorm.rabbitmq


### PR DESCRIPTION
A quick, clean and simple way to bring in proxy support, rather than needing to run a forked version of the playbook.