### PR TITLE
Test for YAML -> Python null -> is defined

### DIFF
--- a/stackstorm.yml
+++ b/stackstorm.yml
@@ -14,6 +14,6 @@
     - StackStorm.st2chatops
     - StackStorm.st2smoketests
     - role: StackStorm.ewc
-      when: ewc_license is defined and ewc_license | length > 0
+      when: (ewc_license is not none) and (ewc_license | length > 0)
     - role: StackStorm.ewc_smoketests
-      when: ewc_license is defined and ewc_license | length > 0
+      when: (ewc_license is not none) and (ewc_license | length > 0)


### PR DESCRIPTION
The playbook sets a default for ewc_license to null (so it is always "defined"), so it should test for none/null, which "is defined" in Jinja/Python.

An earlier commit around this was causing my plays to explode.