### PR TITLE
Move proxy settings for Chatops to respective `StackStorm.st2chatops` role

### DIFF
--- a/roles/StackStorm.st2/tasks/proxy.yml
+++ b/roles/StackStorm.st2/tasks/proxy.yml
@@ -10,7 +10,7 @@
     # NB: Empty ENV var cast to 'None' string in Ansible
     state: "{{ 'present' if ansible_facts.env.get(item.1, 'None') != 'None' else 'absent' }}"
   vars:
-    _services: [st2api, st2actionrunner, st2chatops]
+    _services: [st2api, st2actionrunner]
     _proxy_vars: [http_proxy, https_proxy, no_proxy]
   loop: '{{ _services|product(_proxy_vars)|list }}'
   notify:

--- a/roles/StackStorm.st2chatops/tasks/main.yml
+++ b/roles/StackStorm.st2chatops/tasks/main.yml
@@ -181,6 +181,23 @@
   notify: restart st2chatops
   tags: st2chatops
 
+# Update proxy env vars in st2chatops service config file
+- name: Configure st2chatops to work via proxy
+  become: yes
+  lineinfile:
+    dest: /etc/{{ 'default' if ansible_facts.pkg_mgr == 'apt' else 'sysconfig' }}/{{ item.0 }}
+    create: yes
+    regexp: '^{{ item.1 }}='
+    line: "{{ item.1 }}={{ ansible_facts.env.get(item.1) }}"
+    # NB: Empty ENV var cast to 'None' string in Ansible
+    state: "{{ 'present' if ansible_facts.env.get(item.1, 'None') != 'None' else 'absent' }}"
+  vars:
+    _services: [st2chatops]
+    _proxy_vars: [http_proxy, https_proxy, no_proxy]
+  loop: '{{ _services|product(_proxy_vars)|list }}'
+  notify:
+    - restart st2chatops
+
 - name: Ensure st2chatops service is enabled and running
   become: yes
   service:

--- a/stackstorm.yml
+++ b/stackstorm.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install st2
   hosts: all
-  environment: "{{ st2_proxy_env | default(None) }}"
+  environment: "{{ st2_proxy_env | default({}) }}"
   roles:
     - StackStorm.mongodb
     - StackStorm.rabbitmq


### PR DESCRIPTION
Reverts StackStorm/ansible-st2#239

Move proxy settings for Chatops to respective `StackStorm.st2chatops` role from `StackStorm.st2`.
