### PR TITLE
Fix compatibility with new Ansible 2.8.0

### DIFF
--- a/roles/StackStorm.ewc/tasks/license.yml
+++ b/roles/StackStorm.ewc/tasks/license.yml
@@ -57,7 +57,6 @@
     - enterprise
 
 - name: "Cleanup repo list file from disk"
-  become: yes
   include_tasks: "ewc_repos_cleanup_{{ ansible_facts.pkg_mgr }}.yml"
   when: ewc_license | hash("sha512") != ewc_license_hash
   tags:


### PR DESCRIPTION
Fixes build failure (https://travis-ci.org/StackStorm/ansible-st2/jobs/533578756#L1759) appeared when running under newly released Ansible `2.8.0`:
```
{"reason": "'become' is not a valid attribute for a TaskInclude\n\nThe error appears to be in '/tmp/kitchen/roles/StackStorm.ewc/tasks/license.yml': line 59, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Cleanup repo list file from disk\"\n  ^ here\n"}
```