### PR TITLE
Explicit mark variable as bool

### DIFF
--- a/roles/StackStorm.rabbitmq/tasks/main.yml
+++ b/roles/StackStorm.rabbitmq/tasks/main.yml
@@ -29,5 +29,5 @@
     new_only: no
     # the EL6 RPM for rabbitmq-server does not place the rabbitmq-plugins binary in the search path (other distro's packages do, including EL7). Prefix adds it to the binary search path.
     prefix: "{{ rabbitmq_on_el6 | ternary(rabbitmq_el6_prefix, omit) }}"
-  when: rabbitmq_plugins
+  when: rabbitmq_plugins | bool
   tags: rabbitmq

--- a/roles/StackStorm.st2/tasks/auth.yml
+++ b/roles/StackStorm.st2/tasks/auth.yml
@@ -51,7 +51,7 @@
   file:
     path: /root/.st2
     state: directory
-  when: st2_save_credentials
+  when: st2_save_credentials | bool
 
 - name: auth | Save credentials in CLI configuration file
   become: yes
@@ -65,4 +65,4 @@
       [credentials]
       username = {{ st2_auth_username }}
       password = {{ st2_auth_password }}
-  when: st2_save_credentials
+  when: st2_save_credentials | bool

--- a/roles/StackStorm.st2/tasks/user.yml
+++ b/roles/StackStorm.st2/tasks/user.yml
@@ -38,7 +38,7 @@
     dest: "/etc/sudoers"
     regexp: '^Defaults\s+\+?requiretty'
     replace: '# Defaults requiretty'
-  when: st2_system_user_in_sudoers
+  when: st2_system_user_in_sudoers | bool
 
 - name: user | Configure system user in /etc/st2/st2.conf
   become: yes


### PR DESCRIPTION
Resolve a couple more deprecation warnings, e.g.

```
TASK [StackStorm.st2 : user | Disable requiretty] *************************************************************************************************************************
[DEPRECATION WARNING]: evaluating st2_system_user_in_sudoers as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the
future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```