### PR TITLE
Include centos 7 in condition for installing st2 pack in smoketests

### DIFF
--- a/roles/StackStorm.st2smoketests/tasks/main.yml
+++ b/roles/StackStorm.st2smoketests/tasks/main.yml
@@ -48,8 +48,6 @@
   command: "st2 pack install st2"
   changed_when: no
   when:
-    - ansible_facts.os_family == "RedHat"
-    - ansible_distribution_major_version == "6" or ansible_distribution_major_version == "7"
   tags:
     - smoke-tests
 

--- a/roles/StackStorm.st2smoketests/tasks/main.yml
+++ b/roles/StackStorm.st2smoketests/tasks/main.yml
@@ -47,7 +47,9 @@
     ST2_AUTH_TOKEN: "{{ st2_token.stdout }}"
   command: "st2 pack install st2"
   changed_when: no
-  when: ansible_facts.os_family == "RedHat" and ansible_distribution_major_version == "6"
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - ansible_distribution_major_version == "6" or ansible_distribution_major_version == "7"
   tags:
     - smoke-tests
 

--- a/roles/StackStorm.st2smoketests/tasks/main.yml
+++ b/roles/StackStorm.st2smoketests/tasks/main.yml
@@ -47,7 +47,6 @@
     ST2_AUTH_TOKEN: "{{ st2_token.stdout }}"
   command: "st2 pack install st2"
   changed_when: no
-  when:
   tags:
     - smoke-tests
 


### PR DESCRIPTION
Attempts to fix #251

I have not added any tests.

I am also unsure why there is a condition just for red hat version 6 to install the st2 pack but the next task to `Verify if st2 pack was installed` has no such condition.