### PR TITLE
Minor changes to support Ubuntu Bionic.

### DIFF
--- a/roles/StackStorm.st2/tasks/version.yml
+++ b/roles/StackStorm.st2/tasks/version.yml
@@ -1,7 +1,8 @@
 ---
 # Getting the current st2 version is required to understand which 'st2_services' to restart
 - name: Get installed st2 version
-  command: /opt/stackstorm/st2/bin/python -c 'import st2common; print st2common.__version__'
+  # command: /opt/stackstorm/st2/bin/python -c 'import st2common; print st2common.__version__'
+  command:  /opt/stackstorm/st2/bin/python -c 'import st2common; print (st2common.__version__)'
   changed_when: no
   check_mode: no
   register: _st2_version_installed

--- a/stackstorm.yml
+++ b/stackstorm.yml
@@ -3,12 +3,17 @@
   hosts: all
   environment: "{{ st2_proxy_env | default({}) }}"
   roles:
-    - StackStorm.mongodb
+    - role: StackStorm.mongodb
+      mongodb_version: 4.0
+      mongodb_apt_keys:
+        "3.2": "42F3E95A2C4F08279C4960ADD68FA50FEA312927"
+        "3.4": "0C49F3730359A14518585931BC711F9BA15703C6"
+        "4.0": "9da31620334bd75d9dcb49f368818c72e52529d4"
     - StackStorm.rabbitmq
     - StackStorm.postgresql
     - StackStorm.st2repo
     - StackStorm.st2
-    - StackStorm.st2mistral
+    # - StackStorm.st2mistral
     - StackStorm.nginx
     - StackStorm.st2web
     - StackStorm.nodejs


### PR DESCRIPTION
This makes minor changes necessary to the playbook tasks and variables
which allow them to be executed against Ubuntu Bionic (18.04) hosts.

Changes made include

1. Change MongoDB version to 4.0
2. update MongoDB repo signing keys
3. Update task "Get installed st2 version" to use python3 syntax.
4. Comment out Mistral role, since it is not supported on Ubuntu 18.04

Ref: https://github.com/StackStorm/ansible-st2/issues/249

Signed-off-by: Bruce Becker <bruce.becker@uefa.ch>