### PR TITLE
Improve chatops smoketest resiliency on travis

### DIFF
--- a/roles/StackStorm.st2smoketests/tasks/st2chatops.yml
+++ b/roles/StackStorm.st2smoketests/tasks/st2chatops.yml
@@ -10,7 +10,7 @@
   shell: >
     set -o pipefail &&
     export n=0$(cat $attempts_count_file) &&
-    timeout $(( 9 + 5 ** n )) bash -c '(sleep $(( 4 + 5 ** n )); echo exit ) | bin/hubot';
+    timeout $(( 9 + 6 ** n )) bash -c '(sleep $(( 4 + 6 ** n )); echo exit ) | bin/hubot';
     echo $((n+1)) > $attempts_count_file
   # $a,$n = homegrown exponential backoff (increasing sleep lets the slack client lib retry automatically)
   args:

--- a/roles/StackStorm.st2smoketests/tasks/st2chatops.yml
+++ b/roles/StackStorm.st2smoketests/tasks/st2chatops.yml
@@ -1,17 +1,23 @@
 ---
+- name: Prepare temp file to track retry attempts
+  tempfile:
+    state: file
+  register: attempts_count
+  changed_when: no  # skip idempotence check
+
 - name: Verify st2chatops using bin/hubot
   # when editing, make sure it works for at least 2 adapters: 'shell' and 'slack'
   shell: >
     set -o pipefail &&
-    export a=/tmp/.hubot.{{ 10000 | random }}.attempts &&
-    export n=$(cat $a 2>/dev/null || echo 0) &&
-    timeout $(( 9 + 5 ** n )) bash -c '(sleep $(( 4 + 5 ** n )); echo exit ) | bin/hubot' &&
-    echo $((n+1)) > $a
+    export n=0$(cat $attempts_count_file) &&
+    timeout $(( 9 + 5 ** n )) bash -c '(sleep $(( 4 + 5 ** n )); echo exit ) | bin/hubot';
+    echo $((n+1)) > $attempts_count_file
   # $a,$n = homegrown exponential backoff (increasing sleep lets the slack client lib retry automatically)
   args:
     chdir: /opt/stackstorm/chatops/
     executable: /bin/bash
   environment:
+    attempts_count_file: "{{ attempts_count.path }}"
     HUBOT_LOG_LEVEL: debug
   register: hubot_output
   failed_when: no
@@ -24,6 +30,12 @@
   retries: 3
   # random delay so that retries accross parallel runs don't perfectly align
   delay: "{{ 15 + (7 | random) }}"
+
+- name: Cleanup temp file to track retry attempts
+  file:
+    path: "{{ attempts_count.path }}"
+    state: absent
+  changed_when: no  # skip idempotence check
 
 # Additional task to provide better error message
 - name: Fail if st2chatops couldn't load st2 commands

--- a/roles/StackStorm.st2smoketests/tasks/st2chatops.yml
+++ b/roles/StackStorm.st2smoketests/tasks/st2chatops.yml
@@ -1,7 +1,7 @@
 ---
 - name: Verify st2chatops using bin/hubot
   # when editing, make sure it works for at least 2 adapters: 'shell' and 'slack'
-  shell: set -o pipefail && timeout 10 bash -c '(sleep 5; echo exit ) | bin/hubot'
+  shell: "set -o pipefail && timeout {{ hubot_timeout }} bash -c '(sleep {{ hubot_sleep }}; echo exit ) | bin/hubot'"
   args:
     chdir: /opt/stackstorm/chatops/
     executable: /bin/bash
@@ -10,6 +10,18 @@
   register: hubot_output
   failed_when: no
   changed_when: no
+  # any EADDRINUSE error in stdout is normal (an artifact of the js express http framework)
+  # On Travis, with failures when running many builds in parallel, the real error message is:
+  # "Rate limited, will retry # seconds". This comes from @slack/client (used by hubot-slack).
+  # On success (with Slack), the log says: 'SlackBot#authenticated() Found self in RTM start data'
+  until: "'Rate limited, will retry' not in hubot_output.stdout_lines | last"
+  retries: 3
+  # random delay so that retries accross parallel runs don't perfectly align
+  delay: "{{ 15 + lookup('random_choice', *range(7)) }}"
+  vars:
+    # homegrown exponential backoff (allows the slack client lib to retry automatically)
+    hubot_sleep: "{{ 5 + 5 ** (hubot_output | default({'attempts': 0})).attempts }}"
+    hubot_timeout: "{{ (hubot_sleep | int) + 5 }}"
 
 # Additional task to provide better error message
 - name: Fail if st2chatops couldn't load st2 commands

--- a/roles/StackStorm.st2smoketests/tasks/st2chatops.yml
+++ b/roles/StackStorm.st2smoketests/tasks/st2chatops.yml
@@ -1,8 +1,26 @@
 ---
+# Many parallel builds on travis will trip the slack rate limits.
+# Using ansible's simple retry/until with a constant wait does not improve things,
+# because all of the builds end up retrying at approx the same time.
+# So, this adds an exponential back off (of sorts):
+#
+# There are several parts to this exponential backoff.
+# 1) a temporary file to track the attempts count.
+# 2) hubot's slack client will automatically retry if given the chance
+# 3) we run hubot for a sleep duration allowing st2chatops to work
+# 4) we tell hubot to exit (passed in on stdin)
+# 5) we timeout 5 seconds after the sleep duration has expired
+#    so that if hubot hangs the task still completes.
+#
+# The temporary file (added in one task, used when retrying, and then removed)
+# is necessary because we use the attempts count to inform the backoff, but
+# we the module params are only templated for the first task attempt, so there
+# is no way to pass in the attempts count as ansible retries the task.
+
 - name: Prepare temp file to track retry attempts
   tempfile:
     state: file
-  register: attempts_count
+  register: attempts_count_file
   changed_when: no  # skip idempotence check
 
 - name: Verify st2chatops using bin/hubot
@@ -12,12 +30,24 @@
     export n=0$(cat $attempts_count_file) &&
     timeout $(( 9 + 6 ** n )) bash -c '(sleep $(( 4 + 6 ** n )); echo exit ) | bin/hubot';
     echo $((n+1)) > $attempts_count_file
-  # $a,$n = homegrown exponential backoff (increasing sleep lets the slack client lib retry automatically)
+  # pipefail is good practice with ansible so that subcommands can fail the task quickly.
+  # $attempts_count_file and $n facilitate our exponential backoff algorithm.
+  # $n contains the attempts count.
+  # $n is initialized to 0 if $attempts_count_file is empty (by 0-padding file contents on read)
+  # when n=0: sleep duration is 5 (=4+6^0) and timeout is 10 (=9+6^0)
+  # when n=1: sleep duration is 10 (=4+6^1) and timeout is 15 (=9+6^1)
+  # when n=2: sleep duration is 40 (=4+6^2) and timeout is 45 (=9+6^2)
+  # when n=3: sleep duration is 220 (=4+6^3) and timeout is 225 (=9+6^3)
+  # 
+  # Throughout the sleep duration, hubot's slack client will retry according to rate limit
+  # headers that say to retry after some number of seconds. So, increasing the sleep duration
+  # is important because slack will even out the requests if given the chance.
+  # Each ansible retry is like saying "ignore the retry headers and retry NOW".
   args:
     chdir: /opt/stackstorm/chatops/
     executable: /bin/bash
   environment:
-    attempts_count_file: "{{ attempts_count.path }}"
+    attempts_count_file: "{{ attempts_count_file.path }}"
     HUBOT_LOG_LEVEL: debug
   register: hubot_output
   failed_when: no
@@ -33,7 +63,7 @@
 
 - name: Cleanup temp file to track retry attempts
   file:
-    path: "{{ attempts_count.path }}"
+    path: "{{ attempts_count_file.path }}"
     state: absent
   changed_when: no  # skip idempotence check
 

--- a/roles/StackStorm.st2smoketests/tasks/st2chatops.yml
+++ b/roles/StackStorm.st2smoketests/tasks/st2chatops.yml
@@ -1,7 +1,13 @@
 ---
 - name: Verify st2chatops using bin/hubot
   # when editing, make sure it works for at least 2 adapters: 'shell' and 'slack'
-  shell: "set -o pipefail && timeout {{ hubot_timeout }} bash -c '(sleep {{ hubot_sleep }}; echo exit ) | bin/hubot'"
+  shell: >
+    set -o pipefail &&
+    export a=/tmp/.hubot.{{ 10000 | random }}.attempts &&
+    export n=$(cat $a 2>/dev/null || echo 0) &&
+    timeout $(( 9 + 5 ** n )) bash -c '(sleep $(( 4 + 5 ** n )); echo exit ) | bin/hubot' &&
+    echo $((n+1)) > $a
+  # $a,$n = homegrown exponential backoff (increasing sleep lets the slack client lib retry automatically)
   args:
     chdir: /opt/stackstorm/chatops/
     executable: /bin/bash
@@ -17,11 +23,7 @@
   until: "'Rate limited, will retry' not in hubot_output.stdout_lines | last"
   retries: 3
   # random delay so that retries accross parallel runs don't perfectly align
-  delay: "{{ 15 + lookup('random_choice', *range(7)) }}"
-  vars:
-    # homegrown exponential backoff (allows the slack client lib to retry automatically)
-    hubot_sleep: "{{ 5 + 5 ** (hubot_output | default({'attempts': 0})).attempts }}"
-    hubot_timeout: "{{ (hubot_sleep | int) + 5 }}"
+  delay: "{{ 15 + (7 | random) }}"
 
 # Additional task to provide better error message
 - name: Fail if st2chatops couldn't load st2 commands


### PR DESCRIPTION
This is an attempt to make the travis tests more resilient when running the hubot tests in parallel.
~This will wait for 300 seconds for the port to close (no longer be in use) to avoid the EADDRINUSE error.~
As @armab pointed out, the EADDRINUSE error is a red herring. The real issue is slack Rate limiting. So this adds a retry until to hopefully make more CI runs pass without intervention.