### PR TITLE
fix issue: Installation failed on RH 7 - st2chatops service not found

### DIFF
--- a/roles/StackStorm.st2chatops/tasks/main.yml
+++ b/roles/StackStorm.st2chatops/tasks/main.yml
@@ -202,6 +202,10 @@
   become: yes
   command: systemctl daemon-reload
   
+- name: enable st2chatops
+  become: yes
+  command: systemctl enable st2chatops
+  
 - name: Ensure st2chatops service is enabled and running
   become: yes
   service:

--- a/roles/StackStorm.st2chatops/tasks/main.yml
+++ b/roles/StackStorm.st2chatops/tasks/main.yml
@@ -198,6 +198,10 @@
   notify:
     - restart st2chatops
 
+- name: daemon-reload
+  become: yes
+  command: systemctl daemon-reload
+  
 - name: Ensure st2chatops service is enabled and running
   become: yes
   service:


### PR DESCRIPTION
Fix issue https://github.com/StackStorm/ansible-st2/issues/262

```
- name: daemon-reload
  become: yes
  command: systemctl daemon-reload
  
```