### PR TITLE
[#246]  Drop Ubuntu Trusty support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,13 +23,6 @@ provisioner:
       HUBOT_SLACK_TOKEN: <%= ENV['HUBOT_SLACK_TOKEN'] %>
 
 platforms:
-  # Ubuntu Trusty with Upstart
-  - name: ubuntu-14.04
-    driver_config:
-      image: stackstorm/packagingtest:trusty-upstart
-      platform: ubuntu
-      disable_upstart: false
-      run_command: /sbin/init
   # Ubuntu Xenial with Systemd
   - name: ubuntu-16.04
     driver_config:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,12 @@ branches:
 
 env:
   # default is stable repo
-  - DISTRO=ubuntu-14 LICENSE='BWC_LICENSE_ENTERPRISE'
   - DISTRO=ubuntu-16 LICENSE='BWC_LICENSE_ENTERPRISE'
   - DISTRO=centos-6 LICENSE='BWC_LICENSE_ENTERPRISE'
   - DISTRO=centos-7 LICENSE='BWC_LICENSE_ENTERPRISE'
   - DISTRO=centos-8 LICENSE='BWC_LICENSE_ENTERPRISE'
 
   # StackStorm 'unstable' repo check
-  - DISTRO=ubuntu-14 ST2_REPO=unstable EWC_REPO=enterprise-unstable LICENSE='BWC_LICENSE_ENTERPRISE_UNSTABLE'
   - DISTRO=ubuntu-16 ST2_REPO=unstable EWC_REPO=enterprise-unstable LICENSE='BWC_LICENSE_ENTERPRISE_UNSTABLE'
   - DISTRO=centos-6 ST2_REPO=unstable EWC_REPO=enterprise-unstable LICENSE='BWC_LICENSE_ENTERPRISE_UNSTABLE'
   - DISTRO=centos-7 ST2_REPO=unstable EWC_REPO=enterprise-unstable LICENSE='BWC_LICENSE_ENTERPRISE_UNSTABLE'

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ vagrant up
 
 Other distros:
 ```sh
-vagrant up ubuntu14
 vagrant up centos6
 vagrant up centos7
 vagrant up centos8

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Aka IFTTT orchestration for Ops.
 [![Join our community Slack](https://stackstorm-community.herokuapp.com/badge.svg)](https://stackstorm.com/community-signup)
 
 ## Supported platforms
-* Ubuntu Trusty (14.04)
 * Ubuntu Xenial (16.04)
 * RHEL6 / CentOS6
 * RHEL7 / CentOS7
@@ -102,7 +101,6 @@ There are a few requirements when developing on `ansible-st2`.
 
 These are the platforms we must support (must pass end-to-end testing):
 - Xenial
-- Trusty
 - CentOS6
 - CentOS7
 - CentOS8
@@ -132,7 +130,7 @@ You might be interested in other methods to deploy StackStorm engine:
   * [Puppet Module](https://github.com/stackstorm/puppet-st2)
 
 * Manual Instructions
-  * [Ubuntu 14.04/16.04](https://docs.stackstorm.com/install/deb.html)
+  * [Ubuntu 16.04](https://docs.stackstorm.com/install/deb.html)
   * [RHEL8/CentOS8](https://docs.stackstorm.com/install/rhel8.html)
   * [RHEL7/CentOS7](https://docs.stackstorm.com/install/rhel7.html)
   * [RHEL6/CentOS6](https://docs.stackstorm.com/install/rhel6.html)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,10 +2,6 @@
 # vi: set ft=ruby :
 
 VIRTUAL_MACHINES = {
-  :ubuntu14 => {
-    :hostname => 'ansible-st2-ubuntu14',
-    :box => 'ubuntu/trusty64',
-  },
   :ubuntu16 => {
     :hostname => 'ansible-st2-ubuntu16',
     :box => 'ubuntu/xenial64',

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,7 +16,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.ewc/meta/main.yml
+++ b/roles/StackStorm.ewc/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.ewc_smoketests/meta/main.yml
+++ b/roles/StackStorm.ewc_smoketests/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.mongodb/meta/main.yml
+++ b/roles/StackStorm.mongodb/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.nginx/meta/main.yml
+++ b/roles/StackStorm.nginx/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.nodejs/meta/main.yml
+++ b/roles/StackStorm.nodejs/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.postgresql/meta/main.yml
+++ b/roles/StackStorm.postgresql/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.rabbitmq/meta/main.yml
+++ b/roles/StackStorm.rabbitmq/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.st2/meta/main.yml
+++ b/roles/StackStorm.st2/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.st2chatops/meta/main.yml
+++ b/roles/StackStorm.st2chatops/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.st2mistral/meta/main.yml
+++ b/roles/StackStorm.st2mistral/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.st2repo/meta/main.yml
+++ b/roles/StackStorm.st2repo/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.st2web/meta/main.yml
+++ b/roles/StackStorm.st2web/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: EL
       versions:


### PR DESCRIPTION
Closes #246

Remove `ubuntu trusty` which was dropped since st2 `v3.2.1`