### PR TITLE
Support for Ubuntu 18.04

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,6 +31,14 @@ platforms:
       run_command: /sbin/init
       volume:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  # Ubuntu Bionic with Systemd
+  - name: ubuntu-18.04
+    driver_config:
+      image: stackstorm/packagingtest:bionic-systemd
+      platform: ubuntu
+      run_command: /sbin/init
+      volume:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
   # CentOS7 with Systemd
   - name: centos-7
     driver_config:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,13 @@ branches:
 env:
   # default is stable repo
   - DISTRO=ubuntu-16 LICENSE='BWC_LICENSE_ENTERPRISE'
+  - DISTRO=ubuntu-18 LICENSE='BWC_LICENSE_ENTERPRISE'
   - DISTRO=centos-7 LICENSE='BWC_LICENSE_ENTERPRISE'
   - DISTRO=centos-8 LICENSE='BWC_LICENSE_ENTERPRISE'
 
   # StackStorm 'unstable' repo check
   - DISTRO=ubuntu-16 ST2_REPO=unstable EWC_REPO=enterprise-unstable LICENSE='BWC_LICENSE_ENTERPRISE_UNSTABLE'
+  - DISTRO=ubuntu-18 ST2_REPO=unstable EWC_REPO=enterprise-unstable LICENSE='BWC_LICENSE_ENTERPRISE_UNSTABLE'
   - DISTRO=centos-7 ST2_REPO=unstable EWC_REPO=enterprise-unstable LICENSE='BWC_LICENSE_ENTERPRISE_UNSTABLE'
   - DISTRO=centos-8 ST2_REPO=unstable EWC_REPO=enterprise-unstable LICENSE='BWC_LICENSE_ENTERPRISE_UNSTABLE'
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ st2smoketests, you will need to disable proxy for localhost.
 There are a few requirements when developing on `ansible-st2`.
 
 These are the platforms we must support (must pass end-to-end testing):
-- Xenial
-- Bionic
+- Ubuntu Xenial
+- Ubuntu Bionic
 - CentOS7
 - CentOS8
 - RHEL7 (via AWS)

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Aka IFTTT orchestration for Ops.
 
 ## Supported platforms
 * Ubuntu Xenial (16.04)
+* Ubuntu Bionic (18.04)
 * RHEL7 / CentOS7
 * RHEL8 / CentOS8
 
-> If you're using the provided Vagrantfile, note that it uses Xenial by default.
+> If you're using the provided Vagrantfile, note that it uses Bionic by default.
 
 > In order to access StackStorm Web UI, please don't forget to ensure that http/https ports are opened in your firewall system.
 
@@ -100,6 +101,7 @@ There are a few requirements when developing on `ansible-st2`.
 
 These are the platforms we must support (must pass end-to-end testing):
 - Xenial
+- Bionic
 - CentOS7
 - CentOS8
 - RHEL7 (via AWS)
@@ -107,14 +109,14 @@ These are the platforms we must support (must pass end-to-end testing):
 
 Must also support Ansible Idempotence (Eg. Ansible-playbook re-run should end with the following results: `changed=0.*failed=0`)
 
-For development purposes there is [Vagrantfile](Vagrantfile) available. The following command will setup ubuntu16 box (`ubuntu/xenial64`) by default:
+For development purposes there is [Vagrantfile](Vagrantfile) available. The following command will setup ubuntu18 box (`ubuntu/bionic64`) by default:
 ```sh
 vagrant up
 ```
 
 Other distros:
 ```sh
-vagrant up ubuntu18
+vagrant up ubuntu16
 vagrant up centos7
 vagrant up centos8
 ```
@@ -126,7 +128,8 @@ You might be interested in other methods to deploy StackStorm engine:
   * [Puppet Module](https://github.com/stackstorm/puppet-st2)
 
 * Manual Instructions
-  * [Ubuntu 16.04](https://docs.stackstorm.com/install/deb.html)
+  * [Ubuntu 16.04](https://docs.stackstorm.com/install/u16.html)
+  * [Ubuntu 18.04](https://docs.stackstorm.com/install/u18.html)
   * [RHEL8/CentOS8](https://docs.stackstorm.com/install/rhel8.html)
   * [RHEL7/CentOS7](https://docs.stackstorm.com/install/rhel7.html)
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ vagrant up
 
 Other distros:
 ```sh
+vagrant up ubuntu18
 vagrant up centos7
 vagrant up centos8
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(2) do |config|
   config.ssh.forward_agent = true
 
   VIRTUAL_MACHINES.each do |name, cfg|
-    config.vm.define name, autostart: (name == :ubuntu16) do |vm_config|
+    config.vm.define name, autostart: (name == :ubuntu18) do |vm_config|
       vm_config.vm.hostname = cfg[:hostname]
       vm_config.vm.box = cfg[:box]
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,10 @@ VIRTUAL_MACHINES = {
     :hostname => 'ansible-st2-ubuntu16',
     :box => 'ubuntu/xenial64',
   },
+  :ubuntu18 => {
+    :hostname => 'ansible-st2-ubuntu18',
+    :box => 'ubuntu/bionic64',
+  },
   :centos7 => {
     :hostname => 'ansible-st2-centos7',
     :box => 'centos/7',

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - bionic
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.ewc/meta/main.yml
+++ b/roles/StackStorm.ewc/meta/main.yml
@@ -8,6 +8,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - bionic
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.ewc_smoketests/meta/main.yml
+++ b/roles/StackStorm.ewc_smoketests/meta/main.yml
@@ -8,6 +8,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - bionic
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.mongodb/meta/main.yml
+++ b/roles/StackStorm.mongodb/meta/main.yml
@@ -8,6 +8,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - bionic
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.nginx/meta/main.yml
+++ b/roles/StackStorm.nginx/meta/main.yml
@@ -9,6 +9,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - bionic
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.nodejs/meta/main.yml
+++ b/roles/StackStorm.nodejs/meta/main.yml
@@ -9,6 +9,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - bionic
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.rabbitmq/meta/main.yml
+++ b/roles/StackStorm.rabbitmq/meta/main.yml
@@ -8,6 +8,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - bionic
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.st2/meta/main.yml
+++ b/roles/StackStorm.st2/meta/main.yml
@@ -8,6 +8,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - bionic
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.st2chatops/meta/main.yml
+++ b/roles/StackStorm.st2chatops/meta/main.yml
@@ -8,6 +8,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - bionic
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.st2repo/meta/main.yml
+++ b/roles/StackStorm.st2repo/meta/main.yml
@@ -8,6 +8,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - bionic
         - xenial
     - name: EL
       versions:

--- a/roles/StackStorm.st2web/meta/main.yml
+++ b/roles/StackStorm.st2web/meta/main.yml
@@ -9,6 +9,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - bionic
         - xenial
     - name: EL
       versions:

--- a/stackstorm.yml
+++ b/stackstorm.yml
@@ -6,11 +6,13 @@
     - StackStorm.mongodb
     - StackStorm.rabbitmq
     - role: StackStorm.postgresql
-      when: not (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8')
+      when: not (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8') and
+            not (ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_major_version == '18')
     - StackStorm.st2repo
     - StackStorm.st2
     - role: StackStorm.st2mistral
-      when: not (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8')
+      when: not (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8') and
+            not (ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_major_version == '18')
     - StackStorm.nginx
     - StackStorm.st2web
     - StackStorm.nodejs


### PR DESCRIPTION
Resolves https://github.com/StackStorm/ansible-st2/issues/249

st2mistral role has an added conditional so it doesn't run when on Ubuntu18.04.  This is also applied to the postgresql role dependency.

Ubuntu18.04 added to the virtual machine list in the vagrant file and a small update to the readme to note that Ubuntu 18.04 is available as vagrant box.