### PR TITLE
Add Github Sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# https://stackstorm.com/2020/06/12/sponsoring-stackstorm/
+# FAQ: https://stackstorm.com/donate/
+# Expenses: https://github.com/StackStorm/discussions/issues/36
+community_bridge: stackstorm


### PR DESCRIPTION
StackStorm relies on 3rd party paid services to support its infrastructure and normal day-to-day operation.
See Project Expenses: https://github.com/StackStorm/discussions/issues/36 and FAQ: https://stackstorm.com/donate/

This PR adds Github `Sponsor` button which links to the Linux Foundation Community Bridge platform: https://funding.communitybridge.org/projects/stackstorm where community can support the StackStorm by donating to the project needs.