### PR TITLE
Disable EWC install for unstable packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   # Run Ansible-lint checks
   ansible-lint:
     docker:
-      - image: cytopia/ansible-lint
+      - image: yokogawa/ansible-lint
     steps:
       - checkout
       - run:
@@ -14,8 +14,8 @@ jobs:
       - run:
           name: Ansible-lint check
           command: |
-            cytopia/ansible-lint --version
-            cytopia/ansible-lint -x 204 -v roles/*/*/*.yaml roles/*/*/*.yml stackstorm.yml
+            ansible-lint --version
+            ansible-lint -x 204 -v roles/*/*/*.yaml roles/*/*/*.yml stackstorm.yml
 
   # Run YAML lint checks
   yaml-lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,9 @@ jobs:
   # Run Ansible-lint checks
   ansible-lint:
     docker:
-      - image: williamyeh/ansible:ubuntu16.04
+      - image: cytopia/ansible-lint
     steps:
       - checkout
-      - run:
-          name: Install ansible-lint
-          command: |
-            pip install ansible-lint
-            ansible-lint --version
       - run:
           name: Ansible YAML syntax check
           command: |
@@ -19,7 +14,8 @@ jobs:
       - run:
           name: Ansible-lint check
           command: |
-            ansible-lint -x 204 -v roles/*/*/*.yaml roles/*/*/*.yml stackstorm.yml
+            cytopia/ansible-lint --version
+            cytopia/ansible-lint -x 204 -v roles/*/*/*.yaml roles/*/*/*.yml stackstorm.yml
 
   # Run YAML lint checks
   yaml-lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Ansible-lint check
           command: |
             ansible-lint --version
-            ansible-lint -x 204 -v roles/*/*/*.yaml roles/*/*/*.yml stackstorm.yml
+            ansible-lint -x 106,204,208 -v roles/*/*/*.yaml roles/*/*/*.yml stackstorm.yml
 
   # Run YAML lint checks
   yaml-lint:

--- a/stackstorm.yml
+++ b/stackstorm.yml
@@ -13,6 +13,6 @@
     - StackStorm.st2chatops
     - StackStorm.st2smoketests
     - role: StackStorm.ewc
-      when: ewc_license is defined and ewc_license is not none and ewc_license | length > 0
+      when: ewc_license is defined and ewc_license is not none and ewc_license | length > 1
     - role: StackStorm.ewc_smoketests
-      when: ewc_license is defined and ewc_license is not none and ewc_license | length > 0
+      when: ewc_license is defined and ewc_license is not none and ewc_license | length > 1


### PR DESCRIPTION
Recent change to RBAC in `stackstorm/st2` master broke the EWC install for unstable packages resulting in failed builds (https://travis-ci.org/github/StackStorm/ansible-st2/jobs/730839457).

In this PR I'm just disabling the EWC installation and testing for unstable repositories by setting the `BWC_LICENSE_ENTERPRISE_UNSTABLE` ENV variable to 0.

We should however migrate the EWC role in the future st2 releases as part of https://github.com/StackStorm/ansible-st2/issues/260.