### PR TITLE
Ansible changes for RH 7 and Python3

### DIFF
--- a/roles/StackStorm.nginx/vars/redhat.yml
+++ b/roles/StackStorm.nginx/vars/redhat.yml
@@ -1,3 +1,4 @@
 selinux_dependencies:
   - libsemanage-python
   - libselinux-python
+  - libselinux-python3

--- a/roles/StackStorm.nginx/vars/redhat.yml
+++ b/roles/StackStorm.nginx/vars/redhat.yml
@@ -1,4 +1,3 @@
 selinux_dependencies:
   - libsemanage-python
   - libselinux-python
-  - libselinux-python3

--- a/roles/StackStorm.st2/tasks/main.yml
+++ b/roles/StackStorm.st2/tasks/main.yml
@@ -19,6 +19,7 @@
   register: _rpm_check
   args:
      warn: False
+  ignore_errors: yes
   when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '7'
   # Disable warning as yum doesn't support info
   tags: st2, skip_ansible_lint

--- a/roles/StackStorm.st2/tasks/main.yml
+++ b/roles/StackStorm.st2/tasks/main.yml
@@ -1,4 +1,53 @@
 ---
+- name: Install python3 SELinux policies
+  become: yes
+  yum:
+    name: libselinux-python3
+    state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
+  when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '7' and ansible_selinux.config_mode == "enforcing"
+  tags: st2
+
+- name: Verify python3-devel is available in enabled repo
+  become: yes
+  shell:
+    cmd: yum info python3-devel
+  changed_when: false
+  register: _rpm_check
+  args:
+     warn: False
+  when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '7'
+  # Disable warning as yum doesn't support info
+  tags: st2, skip_ansible_lint
+
+- name: Discover name of optional server rpm
+  become: yes
+  shell:
+    cmd: yum repolist disabled 2> /dev/null | awk -F'/' '/rhel-7-server-rhui-optional-rpms|rhui-REGION-rhel-server-optional|rhel-7-server-optional-rpms/{print $1}'
+  changed_when: false
+  register: _reponame
+  args:
+     warn: False
+  when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '7' and _rpm_check.rc != 0
+  # Disable warning as yum doesn't support repolist
+  tags: st2, skip_ansible_lint
+
+- name: Install python3-devel
+  become: yes
+  yum:
+    name: python3-devel
+    state: present
+    enablerepo: "{{ _reponame.stdout }}"
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
+  when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '7' and _rpm_check.rc != 0
+  tags: st2
+
 - name: Install latest st2 package, auto-update
   become: yes
   package:

--- a/roles/StackStorm.st2/tasks/main.yml
+++ b/roles/StackStorm.st2/tasks/main.yml
@@ -8,7 +8,7 @@
   retries: 5
   delay: 3
   until: _task is succeeded
-  when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '7' and ansible_selinux.config_mode == "enforcing"
+  when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '7' and ansible_selinux.status == "enabled" and ansible_selinux.mode == "enforcing"
   tags: st2
 
 - name: Verify python3-devel is available in enabled repo

--- a/roles/StackStorm.st2/tasks/main.yml
+++ b/roles/StackStorm.st2/tasks/main.yml
@@ -1,16 +1,4 @@
 ---
-- name: Install python3 SELinux policies
-  become: yes
-  yum:
-    name: libselinux-python3
-    state: present
-  register: _task
-  retries: 5
-  delay: 3
-  until: _task is succeeded
-  when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '7' and ansible_selinux.status == "enabled" and ansible_selinux.mode == "enforcing"
-  tags: st2
-
 - name: Verify python3-devel is available in enabled repo
   become: yes
   shell:


### PR DESCRIPTION
Updates for playbooks to install the libselinux-python3 module on EL 7
Updates for playbooks to check that python3-devel is available. If not available then locate the optional server repo and install python3-devel RPM from there. Needed for RHEL where python3-devel is in a disabled repo, and therefore will not get pulled in automatically as a dependency when st2 rpm is installed.

Part of StackStorm/discussions#54