### PR TITLE
Ability to install addition pip modules into the st2 virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Below is the list of variables you can redefine in your playbook to customize st
 | `st2_auth_password`      | `testp`       | Password used by StackStorm standalone authentication.
 | `st2_save_credentials`   | `yes`         | Save credentials for local CLI in `/root/.st2/config` file.
 | `st2_packs`              | `[ st2 ]`     | List of packs to install. This flag does not work with a `--python3` only pack.
+| `st2_python_packages`    | `[ ]`         | List of python packages to install into the `/opt/stackstorm/st2` virtualenv. This is needed when deploying alternative auth or coordination backends which depend on Python modules to make them work.
 | **st2web**
 | `st2web_ssl_certificate`     | `null` | String with custom SSL certificate (`.crt`). If not provided, self-signed certificate will be generated.
 | `st2web_ssl_certificate_key` | `null` | String with custom SSL certificate secret key (`.key`). If not provided, self-signed certificate will be generated.

--- a/roles/StackStorm.st2/defaults/main.yml
+++ b/roles/StackStorm.st2/defaults/main.yml
@@ -37,3 +37,6 @@ st2_save_credentials: yes
 # ST2 packs to be installed (list)
 st2_packs:
   - st2
+
+# Additional python packages to install
+st2_python_packages: []

--- a/roles/StackStorm.st2/tasks/main.yml
+++ b/roles/StackStorm.st2/tasks/main.yml
@@ -84,6 +84,21 @@
     - reload st2
   tags: st2
 
+- name: Install additional Python packages into the st2 virtualenv
+  become: yes
+  pip:
+    name: "{{ item }}"
+    virtualenv: /opt/stackstorm/st2
+    state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
+  with_items: "{{ st2_python_packages }}"
+  notify:
+    - restart st2
+  tags: st2
+
 - name: Perform st2 version related operations
   import_tasks: version.yml
   tags: st2, version


### PR DESCRIPTION
Currently, if using these roles/playbooks to install StackStorm and you want to install a new auth backend or coordination backend, you will most likely need to install some python modules into the `/opt/stackstorm/st2` virtualenv to make it work.

Example, if you want to enable the coordination service and use the`redis` backend, you need to install the `redis` python module into the `/opt/stackstorm/st2` virtualenv.

This PR adds a new variable `st2_python_packages` that accepts a list of python modules to install.