### PR TITLE
Remove st2resultstracker, deprecated since st2 v3.3.0

### DIFF
--- a/roles/StackStorm.st2/vars/main.yml
+++ b/roles/StackStorm.st2/vars/main.yml
@@ -6,7 +6,6 @@ st2_services:
   - st2actionrunner
   - st2garbagecollector
   - st2notifier
-  - st2resultstracker
   - st2rulesengine
   - st2sensorcontainer
   - st2api


### PR DESCRIPTION
This PR fixes CI build failure in the current `master` branch.
A follow-up to https://github.com/StackStorm/st2-packages/pull/683 where `st2resultstracker` service was removed from the packages.
