### PR TITLE
Updates for Ubuntu 16 and Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Below is the list of variables you can redefine in your playbook to customize st
 | `st2_save_credentials`   | `yes`         | Save credentials for local CLI in `/root/.st2/config` file.
 | `st2_packs`              | `[ st2 ]`     | List of packs to install. This flag does not work with a `--python3` only pack.
 | `st2_python_packages`    | `[ ]`         | List of python packages to install into the `/opt/stackstorm/st2` virtualenv. This is needed when deploying alternative auth or coordination backends which depend on Python modules to make them work.
+| `st2_u16_add_insecure_py3_ppa`	| `false`     | Whether permission is granted to install the deadsnakes Python3.6 PPA for Ubuntu 16. 
+
 | **st2web**
 | `st2web_ssl_certificate`     | `null` | String with custom SSL certificate (`.crt`). If not provided, self-signed certificate will be generated.
 | `st2web_ssl_certificate_key` | `null` | String with custom SSL certificate secret key (`.key`). If not provided, self-signed certificate will be generated.

--- a/roles/StackStorm.st2/defaults/main.yml
+++ b/roles/StackStorm.st2/defaults/main.yml
@@ -46,4 +46,4 @@ st2_python_packages: []
 #We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS. Support for Ubuntu 16.04 will be removed with future StackStorm versions.
 #Alternatively the playbooks will  try to add python3.6 from the 3rd party 'deadsnakes' repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa.
 #Only set to true, if you are aware of the support and security risks associated with using unofficial 3rd party PPA repository, and you understand that StackStorm does NOT provide ANY support for python3.6 packages on Ubuntu 16.04.
-u16_add_insecure_py3_ppa: false
+st2_u16_add_insecure_py3_ppa: false

--- a/roles/StackStorm.st2/defaults/main.yml
+++ b/roles/StackStorm.st2/defaults/main.yml
@@ -40,3 +40,10 @@ st2_packs:
 
 # Additional python packages to install
 st2_python_packages: []
+
+# Whether permission is granted to install the deadsnakes Python3.6 PPA for Ubuntu 16. 
+#The python3.6 package is a required dependency for the StackStorm st2 package but that is not installable from any of the default Ubuntu 16.04 repositories.
+#We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS. Support for Ubuntu 16.04 will be removed with future StackStorm versions.
+#Alternatively the playbooks will  try to add python3.6 from the 3rd party 'deadsnakes' repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa.
+#Only set to true, if you are aware of the support and security risks associated with using unofficial 3rd party PPA repository, and you understand that StackStorm does NOT provide ANY support for python3.6 packages on Ubuntu 16.04.
+u16_add_insecure_py3_ppa: false

--- a/roles/StackStorm.st2/tasks/main.yml
+++ b/roles/StackStorm.st2/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Ensure python3.6 is available
+  include_tasks: request_ppa.yml
+  when: ansible_facts.os_family == 'Debian' and ansible_facts.distribution_major_version == '16'
+  tags: st2
+
 - name: Verify python3-devel is available in enabled repo
   become: yes
   shell:

--- a/roles/StackStorm.st2/tasks/request_ppa.yml
+++ b/roles/StackStorm.st2/tasks/request_ppa.yml
@@ -1,0 +1,38 @@
+---
+- name: Verify python3.6 is available in enabled repo
+  become: yes
+  shell:
+    cmd: apt-cache show python3.6
+  changed_when: false
+  register: _pkg_check
+  args:
+     warn: False
+  ignore_errors: yes
+  # Disable warning as package_facts only reports on installed packages
+  tags: st2, skip_ansible_lint
+
+- name: Ask for PPA permission if not available and not already granted
+  pause:
+    prompt: "The python3.6 package is a required dependency for the StackStorm st2 package but that is not installable from any of the default Ubuntu 16.04 repositories. \nWe recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS. Support for Ubuntu 16.04 will be removed with future StackStorm versions.\n\nAlternatively we'll try to add python3.6 from the 3rd party 'deadsnakes' repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa.\nBy continuing you are aware of the support and security risks associated with using unofficial 3rd party PPA repository, and you understand that StackStorm does NOT provide ANY support for python3.6 packages on Ubuntu 16.04.\n\nTo bypass this check in future, you can set the following variable to true: --u16-add-insecure-py3-ppa\n\nEnter [yes] to continue, and adding the PPA"
+  when: '"Version" not in _pkg_check.stdout and not u16_add_insecure_py3_ppa'
+  register: _ppa_request
+  tags: st2
+
+- name: Stop if ppa_permission not granted
+  fail:
+    msg: "Python3.6 PPA installation aborted"
+  when: '"Version" not in _pkg_check.stdout and not u16_add_insecure_py3_ppa and not _ppa_request.user_input | bool'
+  tags: st2
+
+- name: Add PPA key
+  become: yes
+  apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: F23C5A6CF475977595C89F51BA6932366A755776
+  tags: st2
+
+- name: Register python 3.6 PPA
+  become: yes
+  apt_repository:
+    repo: ppa:deadsnakes/ppa
+  tags: st2

--- a/roles/StackStorm.st2/tasks/request_ppa.yml
+++ b/roles/StackStorm.st2/tasks/request_ppa.yml
@@ -13,15 +13,15 @@
 
 - name: Ask for PPA permission if not available and not already granted
   pause:
-    prompt: "The python3.6 package is a required dependency for the StackStorm st2 package but that is not installable from any of the default Ubuntu 16.04 repositories. \nWe recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS. Support for Ubuntu 16.04 will be removed with future StackStorm versions.\n\nAlternatively we'll try to add python3.6 from the 3rd party 'deadsnakes' repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa.\nBy continuing you are aware of the support and security risks associated with using unofficial 3rd party PPA repository, and you understand that StackStorm does NOT provide ANY support for python3.6 packages on Ubuntu 16.04.\n\nTo bypass this check in future, you can set the following variable to true: --u16-add-insecure-py3-ppa\n\nEnter [yes] to continue, and adding the PPA"
-  when: '"Version" not in _pkg_check.stdout and not u16_add_insecure_py3_ppa'
+    prompt: "The python3.6 package is a required dependency for the StackStorm st2 package but that is not installable from any of the default Ubuntu 16.04 repositories. \nWe recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS. Support for Ubuntu 16.04 will be removed with future StackStorm versions.\n\nAlternatively we'll try to add python3.6 from the 3rd party 'deadsnakes' repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa.\nBy continuing you are aware of the support and security risks associated with using unofficial 3rd party PPA repository, and you understand that StackStorm does NOT provide ANY support for python3.6 packages on Ubuntu 16.04.\n\nTo bypass this check in future, you can set the following variable to true: st2_u16_add_insecure_py3_ppa\n\nEnter [yes] to continue, and adding the PPA"
+  when: '"Version" not in _pkg_check.stdout and not st2_u16_add_insecure_py3_ppa'
   register: _ppa_request
   tags: st2
 
 - name: Stop if ppa_permission not granted
   fail:
     msg: "Python3.6 PPA installation aborted"
-  when: '"Version" not in _pkg_check.stdout and not u16_add_insecure_py3_ppa and not _ppa_request.user_input | bool'
+  when: '"Version" not in _pkg_check.stdout and not st2_u16_add_insecure_py3_ppa and not _ppa_request.user_input | bool'
   tags: st2
 
 - name: Add PPA key


### PR DESCRIPTION
Updates to scripts that if Python 3.6 is unavailable on Ubuntu 16 to ask user if they want to install the Deadsnakes PPA.

User can automatically give permission for installation from Deadsnakes PPA  by passing variable st2_u16_add_insecure_py3_ppa with value true