### PR TITLE
Remove Chef from ansible documentation, as it is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ vagrant up centos8
 ## Other Installers
 You might be interested in other methods to deploy StackStorm engine:
 * Configuration Management
-  * [Chef Cookbook](https://github.com/StackStorm/chef-stackstorm/)
   * [Puppet Module](https://github.com/stackstorm/puppet-st2)
 
 * Manual Instructions


### PR DESCRIPTION
Remove reference to Chef as an alternative installer, as the Chef Cookbook has been deprecated.