### PR TITLE
Install ST2 pack with --force

### DIFF
--- a/roles/StackStorm.st2smoketests/tasks/main.yml
+++ b/roles/StackStorm.st2smoketests/tasks/main.yml
@@ -45,7 +45,7 @@
   become: yes
   environment:
     ST2_AUTH_TOKEN: "{{ st2_token.stdout }}"
-  command: "st2 pack install st2"
+  command: "st2 pack install st2 --force"
   changed_when: no
   tags:
     - smoke-tests


### PR DESCRIPTION
Use --force when install ST2 pack to allow for fact that the "stable" ST2 is python2 on CentOS 7 and U16. But the latest st2 pack is marked as python3 only.