### PR TITLE
Pin rabbitmq version on EL8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   # Run Ansible-lint checks
   ansible-lint:
     docker:
-      - image: yokogawa/ansible-lint:4.3.7
+      - image: yokogawa/ansible-lint:v4.3.7
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   # Run Ansible-lint checks
   ansible-lint:
     docker:
-      - image: yokogawa/ansible-lint
+      - image: yokogawa/ansible-lint:4.3.7
     steps:
       - checkout
       - run:
@@ -15,7 +15,7 @@ jobs:
           name: Ansible-lint check
           command: |
             ansible-lint --version
-            ansible-lint -x 106,204,208 -v roles/*/*/*.yml stackstorm.yml
+            ansible-lint -x 106,204,208 -v roles/*/*/*.yaml roles/*/*/*.yml stackstorm.yml
 
   # Run YAML lint checks
   yaml-lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Ansible-lint check
           command: |
             ansible-lint --version
-            ansible-lint -x 106,204,208 -v roles/*/*/*.yaml roles/*/*/*.yml stackstorm.yml
+            ansible-lint -x 106,204,208 -v roles/*/*/*.yml stackstorm.yml
 
   # Run YAML lint checks
   yaml-lint:

--- a/roles/StackStorm.rabbitmq/defaults/main.yml
+++ b/roles/StackStorm.rabbitmq/defaults/main.yml
@@ -3,7 +3,3 @@ rabbitmq_plugins: []
 # To enable the management plugin (in which case you'd want at least one user tagged with administrator):
 #rabbitmq_plugins:
 #  - rabbitmq_management
-# RabbitMQ version to use. Use present for latest. For EL8 we need to pin
-# to 3.8.12 or earlier, as later version requires erlang not available in
-# EL8 or epel repositories
-rabbitmq_version: "{{ '3.8.12' if (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8') else 'present' }}"

--- a/roles/StackStorm.rabbitmq/defaults/main.yml
+++ b/roles/StackStorm.rabbitmq/defaults/main.yml
@@ -3,3 +3,7 @@ rabbitmq_plugins: []
 # To enable the management plugin (in which case you'd want at least one user tagged with administrator):
 #rabbitmq_plugins:
 #  - rabbitmq_management
+# RabbitMQ version to use. Use present for latest. For EL8 we need to pin
+# to 3.8.12 or earlier, as later version requires erlang not available in
+# EL8 or epel repositories
+rabbitmq_version: "{{ '3.8.12' if (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8') else 'present' }}"

--- a/roles/StackStorm.rabbitmq/tasks/main.yml
+++ b/roles/StackStorm.rabbitmq/tasks/main.yml
@@ -46,7 +46,6 @@
 - name: Install pinned rabbitmq package on {{ ansible_facts.distribution }}
   become: yes
   package:
-    name: rabbitmq-server
     name: "rabbitmq-server{{ '=' if ansible_facts.pkg_mgr == 'apt' else '-' }}{{ rabbitmq_version }}"
     state: present
   register: _task

--- a/roles/StackStorm.rabbitmq/tasks/main.yml
+++ b/roles/StackStorm.rabbitmq/tasks/main.yml
@@ -29,7 +29,7 @@
   when: rabbitmq_on_el8
   tags: rabbitmq
 
-- name: Install rabbitmq package on {{ ansible_facts.distribution }}
+- name: Install latest rabbitmq package on {{ ansible_facts.distribution }}
   become: yes
   package:
     name: rabbitmq-server
@@ -41,6 +41,22 @@
   notify:
     - restart rabbitmq
   tags: rabbitmq
+  when: rabbitmq_version == "present"
+
+- name: Install pinned rabbitmq package on {{ ansible_facts.distribution }}
+  become: yes
+  package:
+    name: rabbitmq-server
+    name: "rabbitmq-server{{ '=' if ansible_facts.pkg_mgr == 'apt' else '-' }}{{ rabbitmq_version }}"
+    state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
+  notify:
+    - restart rabbitmq
+  tags: rabbitmq
+  when: rabbitmq_version != "present"
 
 - name: Ensure rabbitmq is enabled and running
   become: yes

--- a/roles/StackStorm.rabbitmq/vars/main.yml
+++ b/roles/StackStorm.rabbitmq/vars/main.yml
@@ -1,2 +1,6 @@
 ---
 rabbitmq_on_el8: "{{ (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8') }}"
+# RabbitMQ version to use. Use present for latest. For EL8 we need to pin
+# to 3.8.12 or earlier, as later version requires erlang not available in
+# EL8 or epel repositories
+rabbitmq_version: "{{ (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8') | ternary('3.8.12','present') }}"


### PR DESCRIPTION
Since rabbitmq-server 3.8.13 was released, installations on EL8 failed as we install latest rabbitmq from rabbitmq packagecloud, But 3.8.13 requires version of erlang that is not in the EL8 or EPEL repositories.

This PR makes the same changes to the ansible scripts as performed by bash installer in https://github.com/StackStorm/st2-packages/pull/693