### PR TITLE
Unpin rabbitmq

### DIFF
--- a/roles/StackStorm.rabbitmq/defaults/main.yml
+++ b/roles/StackStorm.rabbitmq/defaults/main.yml
@@ -3,3 +3,5 @@ rabbitmq_plugins: []
 # To enable the management plugin (in which case you'd want at least one user tagged with administrator):
 #rabbitmq_plugins:
 #  - rabbitmq_management
+# Set to "latest" to latest version, or specify specific version
+rabbitmq_version: "latest"

--- a/roles/StackStorm.rabbitmq/defaults/main.yml
+++ b/roles/StackStorm.rabbitmq/defaults/main.yml
@@ -3,5 +3,5 @@ rabbitmq_plugins: []
 # To enable the management plugin (in which case you'd want at least one user tagged with administrator):
 #rabbitmq_plugins:
 #  - rabbitmq_management
-# Set to "latest" to latest version, or specify specific version
-rabbitmq_version: "latest"
+# Set to "present" to install latest version, or specify specific version
+rabbitmq_version: "present"

--- a/roles/StackStorm.rabbitmq/tasks/main.yml
+++ b/roles/StackStorm.rabbitmq/tasks/main.yml
@@ -12,6 +12,35 @@
   # Disable warning as yum doesn't support enable module
   tags: [rabbitmq, skip_ansible_lint]
 
+- name: Install rabbitmy/erlang from packagecloud for RH 8
+  become: yes
+  no_log: yes
+  yum_repository:
+    name: erlang
+    description: errlang
+    baseurl: https://packagecloud.io/rabbitmq/erlang/el/{{ ansible_facts.distribution_major_version }}/$basearch
+    repo_gpgcheck: yes
+    gpgkey: "https://packagecloud.io/rabbitmq/erlang/gpgkey"
+    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+    metadata_expire: 300
+    gpgcheck: no
+    enabled: yes
+    sslverify: yes
+  when: rabbitmq_on_el8
+  tags: rabbitmq
+
+- name: Install latest rabbitmq erlang package on {{ ansible_facts.distribution }}
+  become: yes
+  package:
+    name: erlang
+    state: present
+  register: _eltask
+  retries: 5
+  delay: 3
+  until: _eltask is succeeded
+  when: rabbitmq_on_el8
+  tags: rabbitmq
+
 - name: Install rabbit from packagecloud for RH 8
   become: yes
   no_log: yes
@@ -41,7 +70,7 @@
   notify:
     - restart rabbitmq
   tags: rabbitmq
-  when: rabbitmq_version == "present"
+  when: rabbitmq_version == "latest"
 
 - name: Install pinned rabbitmq package on {{ ansible_facts.distribution }}
   become: yes
@@ -55,7 +84,7 @@
   notify:
     - restart rabbitmq
   tags: rabbitmq
-  when: rabbitmq_version != "present"
+  when: rabbitmq_version != "latest"
 
 - name: Ensure rabbitmq is enabled and running
   become: yes

--- a/roles/StackStorm.rabbitmq/tasks/main.yml
+++ b/roles/StackStorm.rabbitmq/tasks/main.yml
@@ -16,8 +16,8 @@
   become: yes
   no_log: yes
   yum_repository:
-    name: erlang
-    description: errlang
+    name: rabbitmq_erlang
+    description: rabbitmq_erlang
     baseurl: https://packagecloud.io/rabbitmq/erlang/el/{{ ansible_facts.distribution_major_version }}/$basearch
     repo_gpgcheck: yes
     gpgkey: "https://packagecloud.io/rabbitmq/erlang/gpgkey"

--- a/roles/StackStorm.rabbitmq/tasks/main.yml
+++ b/roles/StackStorm.rabbitmq/tasks/main.yml
@@ -70,7 +70,7 @@
   notify:
     - restart rabbitmq
   tags: rabbitmq
-  when: rabbitmq_version == "latest"
+  when: rabbitmq_version == "present"
 
 - name: Install pinned rabbitmq package on {{ ansible_facts.distribution }}
   become: yes
@@ -84,7 +84,7 @@
   notify:
     - restart rabbitmq
   tags: rabbitmq
-  when: rabbitmq_version != "latest"
+  when: rabbitmq_version != "present"
 
 - name: Ensure rabbitmq is enabled and running
   become: yes

--- a/roles/StackStorm.rabbitmq/vars/main.yml
+++ b/roles/StackStorm.rabbitmq/vars/main.yml
@@ -1,6 +1,2 @@
 ---
 rabbitmq_on_el8: "{{ (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8') }}"
-# RabbitMQ version to use. Use present for latest. For EL8 we need to pin
-# to 3.8.12 or earlier, as later version requires erlang not available in
-# EL8 or epel repositories
-rabbitmq_version: "{{ (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8') | ternary('3.8.12','present') }}"


### PR DESCRIPTION
Stop pinning version of rabbitmq on EL8.

Install latest from packagecloud, and therefore as that requires newer version of erlang, install the minimal erland provided by rabbitmq - as per instructions at https://github.com/rabbitmq/erlang-rpm

Relates to https://github.com/StackStorm/st2-packages/pull/699