### PR TITLE
Download GPG key explicitly

### DIFF
--- a/roles/StackStorm.epel/tasks/main.yml
+++ b/roles/StackStorm.epel/tasks/main.yml
@@ -6,6 +6,14 @@
   when: ansible_facts.os_family == "RedHat"
   tags: epel
 
+- name: Install GPG key
+  become: yes
+  rpm_key:
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_facts.distribution_major_version }}
+    state: present
+  when: ansible_facts.os_family == "RedHat" and not epel_installed.stat.exists
+  tags: epel
+
 - name: Install EPEL repo
   become: yes
   yum:


### PR DESCRIPTION
Closes https://github.com/StackStorm/ansible-st2/issues/292

Not sure why this has started to fail recently. But downloaded the key first, ensures that it downloads successfully.

On bash installers as we use -y then it will install without issue