### PR TITLE
Fix problem installing specific version of ST2

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Below is the list of variables you can redefine in your playbook to customize st
 | `st2_python_packages`    | `[ ]`         | List of python packages to install into the `/opt/stackstorm/st2` virtualenv. This is needed when deploying alternative auth or coordination backends which depend on Python modules to make them work.
 | `st2_u16_add_insecure_py3_ppa`	| `false`     | Whether permission is granted to install the deadsnakes Python3.6 PPA for Ubuntu 16. 
 | **st2web**
+| `st2web_version`     | `latest`      | st2web version to install. `present` to install available package, `latest` to get automatic updates, or pin it to numeric version like `2.2.0` or with revision like `2.2.0-1`.
 | `st2web_ssl_certificate`     | `null` | String with custom SSL certificate (`.crt`). If not provided, self-signed certificate will be generated.
 | `st2web_ssl_certificate_key` | `null` | String with custom SSL certificate secret key (`.key`). If not provided, self-signed certificate will be generated.
 | `st2web_nginx_config`     | `null` | String with a custom nginx configuration file (`st2.conf`). If not provided, the default st2.conf will be used.
-| `st2web_version`     | `latest`      | st2web version to install. `present` to install available package, `latest` to get automatic updates, or pin it to numeric version like `2.2.0` or with revision like `2.2.0-1`.
 | **ewc**
 | `ewc_license`            | `null`        | EWC license key is required for installing EWC enteprise bits via this ansible role.
 | `ewc_repo`               | `enterprise`  | EWC PackageCloud repository to install. [`enterprise`](https://packagecloud.io/StackStorm/enterprise/), [`enterprise-unstable`](https://packagecloud.io/StackStorm/enterprise-unstable/), [`staging-enterprise`](https://packagecloud.io/StackStorm/staging-enteprise/), [`staging-enterprise-unstable`](https://packagecloud.io/StackStorm/staging-enterprise-unstable/)

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ Below is the list of variables you can redefine in your playbook to customize st
 | **st2repo**
 | `st2repo_name`           | `stable`      | StackStorm PackageCloud repository to install. [`stable`](https://packagecloud.io/StackStorm/stable/), [`unstable`](https://packagecloud.io/StackStorm/unstable/), [`staging-stable`](https://packagecloud.io/StackStorm/staging-stable/), [`staging-unstable`](https://packagecloud.io/StackStorm/staging-unstable/)
 | **st2**
-| `st2_version`            | `latest`      | StackStorm version to install. `present` to install available package, `latest` to get automatic updates, or pin it to numeric version like `2.2.0`.
-| `st2_revision`           | `1`           | StackStorm revision to install. Used only with pinned `st2_version`.
+| `st2_version`            | `latest`      | StackStorm version to install. `present` to install available package, `latest` to get automatic updates, or pin it to numeric version like `2.2.0` or with revision like `2.2.0-1`
 | `st2_config`             | `{}`          | Hash with StackStorm configuration settings to set in [`st2.conf`](https://github.com/StackStorm/st2/blob/master/conf/st2.conf.sample) ini file.
 | `st2_system_user`        | `stanley`     | System user from which st2 will execute local/remote shell actions.
 | `st2_system_user_in_sudoers` | `yes`| Add `st2_system_user` to the sudoers (recommended for most `st2` features to work).
@@ -52,6 +51,7 @@ Below is the list of variables you can redefine in your playbook to customize st
 | `st2web_ssl_certificate`     | `null` | String with custom SSL certificate (`.crt`). If not provided, self-signed certificate will be generated.
 | `st2web_ssl_certificate_key` | `null` | String with custom SSL certificate secret key (`.key`). If not provided, self-signed certificate will be generated.
 | `st2web_nginx_config`     | `null` | String with a custom nginx configuration file (`st2.conf`). If not provided, the default st2.conf will be used.
+| `st2web_version`     | `latest`      | st2web version to install. `present` to install available package, `latest` to get automatic updates, or pin it to numeric version like `2.2.0` or with revision like `2.2.0-1`.
 | **ewc**
 | `ewc_license`            | `null`        | EWC license key is required for installing EWC enteprise bits via this ansible role.
 | `ewc_repo`               | `enterprise`  | EWC PackageCloud repository to install. [`enterprise`](https://packagecloud.io/StackStorm/enterprise/), [`enterprise-unstable`](https://packagecloud.io/StackStorm/enterprise-unstable/), [`staging-enterprise`](https://packagecloud.io/StackStorm/staging-enteprise/), [`staging-enterprise-unstable`](https://packagecloud.io/StackStorm/staging-enterprise-unstable/)
@@ -60,7 +60,7 @@ Below is the list of variables you can redefine in your playbook to customize st
 | `ewc_rbac` | [See `ewc_rbac` variable in role defaults](roles/StackStorm.ewc/defaults/main.yml) | EWC RBAC roles and assignments. This is a dictionary with two keys `roles` and `assignments`. `roles` and `assignments` are in turn both arrays. Each element in the array follows the exact YAML schema for [roles](https://ewc-docs.extremenetworks.com/rbac.html#user-permissions) and [assignments](https://ewc-docs.extremenetworks.com/rbac.html#defining-user-role-assignments) defined in EWC documentation.
 | `ewc_ldap` | [See `ewc_ldap` variable in role defaults](roles/StackStorm.ewc/defaults/main.yml) | Settings for EWC LDAP authentication backend. `ewc_ldap` is a dictionary and has one item `backend_kwargs`. `backend_kwargs` should be provided as exactly listed in EWC documentation for [LDAP configuration](https://ewc-docs.extremenetworks.com/authentication.html#auth-backends).
 | **st2chatops**
-| `st2chatops_version`     | `latest`      | st2chatops version to install. `present` to install available package, `latest` to get automatic updates, or pin it to numeric version like `2.2.0`.
+| `st2chatops_version`     | `latest`      | st2chatops version to install. `present` to install available package, `latest` to get automatic updates, or pin it to numeric version like `2.2.0` or with revision like `2.2.0-1`.
 | `st2chatops_st2_api_key` |               | st2 API key to be updated in st2chatops.env using "st2 apikey create -k" in a task
 | `st2chatops_hubot_adapter` |             | Hubot Adapter to be used for st2chatops. Default is `shell`, but should be changed to one of the [`supported adapters`](`https://github.com/StackStorm/ansible-st2/blob/master/roles/st2chatops/vars/main.yml`).[**Required**]
 | `st2chatops_config`      | `{ }`         | Based on adapter in `st2chatops_hubot_adapter`, provide hash for the adapter settings, to update [`st2chatops.env`](https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env). For example, for `Slack` hubot adapter: `st2chatops_config:` `HUBOT_SLACK_TOKEN: xoxb-CHANGE-ME-PLEASE`

--- a/roles/StackStorm.st2/defaults/main.yml
+++ b/roles/StackStorm.st2/defaults/main.yml
@@ -1,8 +1,7 @@
 ---
 # StackStorm version to install. `present` to install available package, `latest` to get automatic updates or pin it to numeric version like `2.2.0`.
+# On Debian need to specify revision of package like `2.2.0-1`.
 st2_version: latest
-# StackStorm revision to install. Used only with pinned `st2_version`.
-st2_revision: 1
 
 # Hash with StackStorm configuration settings to set in 'st2.conf' ini file
 # See https://github.com/StackStorm/st2/blob/master/conf/st2.conf.sample for a full list

--- a/roles/StackStorm.st2/tasks/main.yml
+++ b/roles/StackStorm.st2/tasks/main.yml
@@ -75,7 +75,7 @@
 - name: Install pinned st2 package
   become: yes
   package:
-    name: st2{{ '-' if ansible_facts.pkg_mgr == 'yum' else '=' }}{{ st2_version }}-{{ st2_revision }}
+    name: st2{{ '=' if ansible_facts.pkg_mgr == 'apt' else '-' }}{{ st2_version }}
     state: present
   register: _task
   retries: 5

--- a/roles/StackStorm.st2chatops/tasks/main.yml
+++ b/roles/StackStorm.st2chatops/tasks/main.yml
@@ -46,13 +46,15 @@
 - name: Install pinned st2chatops package
   become: yes
   package:
-    name: st2chatops{{ '-' if ansible_facts.pkg_mgr == 'yum' else '=' }}{{ st2chatops_version }}
+    name: st2chatops{{ '=' if ansible_facts.pkg_mgr == 'apt' else '-' }}{{ st2chatops_version }}
     state: present
   register: _task
   retries: 5
   delay: 3
   until: _task is succeeded
-  when: st2chatops_version != "latest"
+  when:
+    - st2chatops_version != "latest"
+    - st2chatops_version != "present"
   notify:
     - restart st2chatops
   tags: st2chatops

--- a/roles/StackStorm.st2web/defaults/main.yml
+++ b/roles/StackStorm.st2web/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # defaults file for st2web
-st2web_revision: 1
+# StackStorm st2web version to install. `present` to install available package, `latest` to get automatic updates or pin it to numeric version like `2.2.0`.
+# On Debian need to specify revision of package like `2.2.0-1`.
+st2web_version: latest
 
 # String with custom SSL certificate. If not provided, self-signed certificate will be generated.
 st2web_ssl_certificate: null

--- a/roles/StackStorm.st2web/tasks/main.yml
+++ b/roles/StackStorm.st2web/tasks/main.yml
@@ -20,7 +20,7 @@
   retries: 5
   delay: 3
   until: _task is succeeded
-  when: st2_version == "latest"
+  when: st2web_version == "latest"
   tags: st2web, skip_ansible_lint
 
 - name: Install present {{ st2web_package_name }} package, no auto-update
@@ -32,21 +32,21 @@
   retries: 5
   delay: 3
   until: _task is succeeded
-  when: st2_version == "present"
+  when: st2web_version == "present"
   tags: st2web
 
 - name: Install pinned {{ st2web_package_name }} package
   become: yes
   package:
-    name: "{{ st2web_package_name }}{{ '-' if ansible_facts.pkg_mgr == 'yum' else '=' }}{{ st2_version }}-{{ st2web_revision }}"
+    name: "{{ st2web_package_name }}{{ '=' if ansible_facts.pkg_mgr == 'apt' else '-' }}{{ st2web_version }}"
     state: present
   register: _task
   retries: 5
   delay: 3
   until: _task is succeeded
   when:
-    - st2_version != "latest"
-    - st2_version != "present"
+    - st2web_version != "latest"
+    - st2web_version != "present"
   tags: st2web
 
 - name: Configure SSL certificate for st2web UI


### PR DESCRIPTION
Currently the playbooks do not work if you want to specify a particular version of ST2.

The problems were:

- wrong check on using = or - as separately, as logic was if yum else do ... But newer EL are dnf - and so were using the apt separator
- st2_version was used for both st2 and st2web packages. And if specified always had to specify st2_revision. This only works if the same revision exists for both packages, but this isn't necessarily the case e.g. 3.4.0 has 3.4.0-1 for st2, and 3.4.0-3 on st2web
- On EL systems then there is no need to specify revisions, if use 3.4.0 it would give the latest version. But on Debian the revision needs to be specified
- st2chatops was insatlled differntly with a single st2chatops_version that could be used as with or without revision

These issues were raised in https://github.com/StackStorm/ansible-st2/issues/150
Closes #150

Updated the playboosk to use the current revision separate for Debian and EL.
Updated the playbooks to use a consistent approach for revisioning, using st2_version, st2chatops_version and st2web_version. This allows the user to either specify with revision for EL and Debian, or they can omit revision on EL.