### PR TITLE
Add support for nodejs 14 and list the variable on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Below is the list of variables you can redefine in your playbook to customize st
 | `st2web_ssl_certificate_key` | `null` | String with custom SSL certificate secret key (`.key`). If not provided, self-signed certificate will be generated.
 | `st2web_nginx_config`     | `null` | String with a custom nginx configuration file (`st2.conf`). If not provided, the default st2.conf will be used.
 | **st2chatops**
+| `nodejs_major_version`   | `14`          | The default for releases before StackStorm 3.5.0 is Nodejs 10. Adapt the version to your requirements if you have a special setup that's not covered by the defaults.
 | `st2chatops_version`     | `latest`      | st2chatops version to install. `present` to install available package, `latest` to get automatic updates, or pin it to numeric version like `2.2.0` or with revision like `2.2.0-1`.
 | `st2chatops_st2_api_key` |               | st2 API key to be updated in st2chatops.env using "st2 apikey create -k" in a task
 | `st2chatops_hubot_adapter` |             | Hubot Adapter to be used for st2chatops. Default is `shell`, but should be changed to one of the [`supported adapters`](`https://github.com/StackStorm/ansible-st2/blob/master/roles/st2chatops/vars/main.yml`).[**Required**]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Below is the list of variables you can redefine in your playbook to customize st
 | `st2web_ssl_certificate_key` | `null` | String with custom SSL certificate secret key (`.key`). If not provided, self-signed certificate will be generated.
 | `st2web_nginx_config`     | `null` | String with a custom nginx configuration file (`st2.conf`). If not provided, the default st2.conf will be used.
 | **st2chatops**
-| `nodejs_major_version`   | `14`          | The default for releases before StackStorm 3.5.0 is Nodejs 10. Adapt the version to your requirements if you have a special setup that's not covered by the defaults.
+| `nodejs_major_version`   | `14`          | The default fits st2chatops version >= 3.5.0.
 | `st2chatops_version`     | `latest`      | st2chatops version to install. `present` to install available package, `latest` to get automatic updates, or pin it to numeric version like `2.2.0` or with revision like `2.2.0-1`.
 | `st2chatops_st2_api_key` |               | st2 API key to be updated in st2chatops.env using "st2 apikey create -k" in a task
 | `st2chatops_hubot_adapter` |             | Hubot Adapter to be used for st2chatops. Default is `shell`, but should be changed to one of the [`supported adapters`](`https://github.com/StackStorm/ansible-st2/blob/master/roles/st2chatops/vars/main.yml`).[**Required**]

--- a/roles/StackStorm.nodejs/defaults/main.yml
+++ b/roles/StackStorm.nodejs/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # nodejs version to install
-nodejs_major_version: "{% if st2_version == 'latest' %}14{% elif st2_version is version('3.5.0', '<') %}10{% else %}14{% endif %}"
+nodejs_major_version: "{% if st2_version == 'latest' or st2_version is version('3.5.0', '<') %}14{% else %}10{% endif %}"

--- a/roles/StackStorm.nodejs/defaults/main.yml
+++ b/roles/StackStorm.nodejs/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # nodejs version to install
-nodejs_major_version: "10"
+nodejs_major_version: "{% if st2_version == 'latest' %}14{% elif st2_version is version('3.5.0', '<') %}10{% else %}14{% endif %}"

--- a/roles/StackStorm.nodejs/defaults/main.yml
+++ b/roles/StackStorm.nodejs/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # nodejs version to install
-nodejs_major_version: "{% if st2_version == 'latest' or st2_version is version('3.5.0', '<') %}14{% else %}10{% endif %}"
+nodejs_major_version: "{% if st2chatops_version == 'latest' or st2chatops_version is version('3.5.0', '>=') %}14{% else %}10{% endif %}"

--- a/roles/StackStorm.nodejs/defaults/main.yml
+++ b/roles/StackStorm.nodejs/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # nodejs version to install
-nodejs_major_version: "{% if st2chatops_version == 'latest' or st2chatops_version is version('3.5.0', '>=') %}14{% else %}10{% endif %}"
+nodejs_major_version: "14"


### PR DESCRIPTION
There were different ways to realize the node 14 support but this one is the only one that's not breaking. 

Changing just the default would break deployments of older releases even though we may mention it on the README. 2nd challenge was that a simple comparison with the ansible version test is not able to work with `latest` as st2_version. That's why we use an if-elsif-else and not just an if-else clause here. 