### PR TITLE
Generate self-signed certificates with subject alternative name

### DIFF
--- a/roles/StackStorm.st2web/tasks/certificate.yml
+++ b/roles/StackStorm.st2web/tasks/certificate.yml
@@ -33,10 +33,35 @@
   when: st2web_ssl_certificate and st2web_ssl_certificate_key
 
 - name: Generate self-signed SSL certificate
+  # openssl >= 1.1.1 is required to specify the SubjectAltName (SAN) via arguments
   become: yes
-  shell: openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt -days 365 -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information Technology/CN=$(hostname)"
+  shell: openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt -days 365 -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information Technology/CN=$(hostname)" -addext "subjectAltName=DNS:$(hostname)"
   args:
     creates: /etc/ssl/st2/st2.key
   notify:
     - restart nginx
-  when: not st2web_ssl_certificate and not st2web_ssl_certificate_key
+  when:
+    - not st2web_ssl_certificate
+    - not st2web_ssl_certificate_key
+    - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7')
+
+- name: Generate self-signed SSL certificate on RedHat 7
+  # RedHat 7 comes with openssl 1.0.2k-fips which requires an extra openssl.conf to specify the SAN
+  become: yes
+  block:
+    - name: Render openssl.cnf
+      ansible.builtin.template:
+        src: openssl.cnf.j2
+        dest: /opt/stackstorm/openssl.cnf
+        mode: '0644'
+    - name: Generate self-signed SSL certificate on RedHat 7
+      shell: openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt -days 365 -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information Technology/CN=$(hostname)" -config /opt/stackstorm/openssl.cnf
+      args:
+        creates: /etc/ssl/st2/st2.key
+      notify:
+        - restart nginx
+  when:
+    - not st2web_ssl_certificate
+    - not st2web_ssl_certificate_key
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version == '7'

--- a/roles/StackStorm.st2web/templates/openssl.cnf.j2
+++ b/roles/StackStorm.st2web/templates/openssl.cnf.j2
@@ -1,0 +1,16 @@
+[ req ]
+x509_extensions = v3_req
+distinguished_name = dn
+
+[ dn ]
+C = US
+ST = California
+L = Palo Alto
+O = StackStorm
+OU = Information Technology
+
+[ alternate_names ]
+DNS.1 = {{ ansible_hostname }}
+
+[ v3_req ]
+subjectAltName = @alternate_names


### PR DESCRIPTION
Now we create self-signed certificates with an SubjectAlternativeName as requested in #293 

close #293 