### PR TITLE
Allow Erlang version on EL8 to be pinned, and by default use < 25

### DIFF
--- a/roles/StackStorm.rabbitmq/defaults/main.yml
+++ b/roles/StackStorm.rabbitmq/defaults/main.yml
@@ -6,4 +6,4 @@ rabbitmq_plugins: []
 # Set to "present" to install latest version, or specify specific version
 rabbitmq_version: "present"
 # Use version or wildcard
-erlang_el8_version: "24*"
+erlang_version: "{% if ansible_facts.os_family == 'Redhat' and ansible_facts.distribution_major_version == '8' %}24*{% else %}present{% endif %}"

--- a/roles/StackStorm.rabbitmq/defaults/main.yml
+++ b/roles/StackStorm.rabbitmq/defaults/main.yml
@@ -5,3 +5,5 @@ rabbitmq_plugins: []
 #  - rabbitmq_management
 # Set to "present" to install latest version, or specify specific version
 rabbitmq_version: "present"
+# Use version or wildcard
+erlang_el8_version: "24*"

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_redhat.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_redhat.yml
@@ -47,7 +47,7 @@
 - name: Install pinned erlang package on {{ ansible_facts.distribution }}
   become: yes
   package:
-    name: erlang-{{erlang_el8_version}}
+    name: erlang-{{ erlang_el8_version }}
     state: present
   register: _eltask
   retries: 5

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_redhat.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_redhat.yml
@@ -42,3 +42,16 @@
   delay: 3
   until: _eltask is succeeded
   tags: rabbitmq
+  when: erlang_el8_version == "present"
+
+- name: Install pinned erlang package on {{ ansible_facts.distribution }}
+  become: yes
+  package:
+    name: erlang-{{erlang_el8_version}}
+    state: present
+  register: _eltask
+  retries: 5
+  delay: 3
+  until: _eltask is succeeded
+  tags: rabbitmq
+  when: erlang_el8_version != "present"

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_redhat.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_redhat.yml
@@ -42,16 +42,16 @@
   delay: 3
   until: _eltask is succeeded
   tags: rabbitmq
-  when: erlang_el8_version == "present"
+  when: erlang_version == "present"
 
 - name: Install pinned erlang package on {{ ansible_facts.distribution }}
   become: yes
   package:
-    name: erlang-{{ erlang_el8_version }}
+    name: erlang-{{ erlang_version }}
     state: present
   register: _eltask
   retries: 5
   delay: 3
   until: _eltask is succeeded
   tags: rabbitmq
-  when: erlang_el8_version != "present"
+  when: erlang_version != "present"


### PR DESCRIPTION
Install on EL8 started to fail on RabbitMQ install. Problems reported "please re-compile this module with an Erlang/OTP 25 compiler"

Erlang 25 has been pushed to the RabbitMQ erlang repository, but according to https://www.rabbitmq.com/which-erlang.html erlang 25 support is preview.

Update so that erlang version can be specified, and make the default value 24* so do not pick up 25.