### PR TITLE
Use version of erlang < 1.25 and fix EL8 passlib

### DIFF
--- a/roles/StackStorm.rabbitmq/defaults/main.yml
+++ b/roles/StackStorm.rabbitmq/defaults/main.yml
@@ -6,4 +6,4 @@ rabbitmq_plugins: []
 # Set to "present" to install latest version, or specify specific version
 rabbitmq_version: "present"
 # Use version or wildcard
-erlang_version: "{% if ansible_facts.os_family == 'Redhat' and ansible_facts.distribution_major_version == '8' %}24*{% elif ansible_facts.os_family == 'Debian' %}1:22.2.7+dfsg-1{% else %}present{% endif %}"
+erlang_version: "{% if ansible_facts.os_family == 'Redhat' and ansible_facts.distribution_major_version == '8' %}24*{% elif ansible_facts.os_family == 'Debian' %}1:24.3.4-1{% else %}present{% endif %}"

--- a/roles/StackStorm.rabbitmq/defaults/main.yml
+++ b/roles/StackStorm.rabbitmq/defaults/main.yml
@@ -6,4 +6,4 @@ rabbitmq_plugins: []
 # Set to "present" to install latest version, or specify specific version
 rabbitmq_version: "present"
 # Use version or wildcard
-erlang_version: "{% if ansible_facts.os_family == 'Redhat' and ansible_facts.distribution_major_version == '8' %}24*{% else %}present{% endif %}"
+erlang_version: "{% if ansible_facts.os_family == 'Redhat' and ansible_facts.distribution_major_version == '8' %}24*{% elif ansible_facts.os_family == 'Debian' %} 1:24.3.4{% else %}present{% endif %}"

--- a/roles/StackStorm.rabbitmq/defaults/main.yml
+++ b/roles/StackStorm.rabbitmq/defaults/main.yml
@@ -6,4 +6,4 @@ rabbitmq_plugins: []
 # Set to "present" to install latest version, or specify specific version
 rabbitmq_version: "present"
 # Use version or wildcard
-erlang_version: "{% if ansible_facts.os_family == 'Redhat' and ansible_facts.distribution_major_version == '8' %}24*{% elif ansible_facts.os_family == 'Debian' %}1.22.2.7+dfsg-1{% else %}present{% endif %}"
+erlang_version: "{% if ansible_facts.os_family == 'Redhat' and ansible_facts.distribution_major_version == '8' %}24*{% elif ansible_facts.os_family == 'Debian' %}1:22.2.7+dfsg-1{% else %}present{% endif %}"

--- a/roles/StackStorm.rabbitmq/defaults/main.yml
+++ b/roles/StackStorm.rabbitmq/defaults/main.yml
@@ -6,4 +6,4 @@ rabbitmq_plugins: []
 # Set to "present" to install latest version, or specify specific version
 rabbitmq_version: "present"
 # Use version or wildcard
-erlang_version: "{% if ansible_facts.os_family == 'Redhat' and ansible_facts.distribution_major_version == '8' %}24*{% elif ansible_facts.os_family == 'Debian' %} 1:24.3.4{% else %}present{% endif %}"
+erlang_version: "{% if ansible_facts.os_family == 'Redhat' and ansible_facts.distribution_major_version == '8' %}24*{% elif ansible_facts.os_family == 'Debian' %}1.22.2.7+dfsg-1{% else %}present{% endif %}"

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -65,19 +65,37 @@
 - name: Install latest erlang packages on {{ ansible_facts.distribution }}
   become: yes
   package:
-    name: "erlang"
+    name: "{{item}}"
     state: present
   register: _eltask
   retries: 5
   delay: 3
   until: _eltask is succeeded
   tags: rabbitmq
+  loop:
+    - erlang-base
+    - erlang-asn1
+    - erlang-crypto
+    - erlang-eldap
+    - erlang-ftp
+    - erlang-inets
+    - erlang-mnesia
+    - erlang-os-mon
+    - erlang-parsetools
+    - erlang-public-key
+    - erlang-runtime-tools
+    - erlang-snmp
+    - erlang-ssl
+    - erlang-syntax-tools
+    - erlang-tftp
+    - erlang-tools
+    - erlang-xmerl
   when: erlang_version == "present"
 
 - name: Install latest erlang packages on {{ ansible_facts.distribution }}
   become: yes
   package:
-    name: "erlang={{erlang_version}}"
+    name: "{{item}}={{erlang_version}}"
     state: present
   register: _eltask
   retries: 5
@@ -85,3 +103,21 @@
   until: _eltask is succeeded
   tags: rabbitmq
   when: erlang_version != "present"
+  loop:
+    - erlang-base
+    - erlang-asn1
+    - erlang-crypto
+    - erlang-eldap
+    - erlang-ftp
+    - erlang-inets
+    - erlang-mnesia
+    - erlang-os-mon
+    - erlang-parsetools
+    - erlang-public-key
+    - erlang-runtime-tools
+    - erlang-snmp
+    - erlang-ssl
+    - erlang-syntax-tools
+    - erlang-tftp
+    - erlang-tools
+    - erlang-xmerl

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -92,7 +92,7 @@
     - erlang-xmerl
   when: erlang_version == "present"
 
-- name: Install latest erlang packages on {{ ansible_facts.distribution }}
+- name: Install pinned erlang packages on {{ ansible_facts.distribution }}
   become: yes
   package:
     name: "{{item}}={{erlang_version}}"

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -65,28 +65,10 @@
 - name: Install latest erlang packages on {{ ansible_facts.distribution }}
   become: yes
   package:
-    name: "{{ item }}"
+    name: "erlang"
     state: present
   register: _eltask
   retries: 5
   delay: 3
   until: _eltask is succeeded
   tags: rabbitmq
-  loop:
-    - erlang-base
-    - erlang-asn1
-    - erlang-crypto
-    - erlang-eldap
-    - erlang-ftp
-    - erlang-inets
-    - erlang-mnesia
-    - erlang-os-mon
-    - erlang-parsetools
-    - erlang-public-key
-    - erlang-runtime-tools
-    - erlang-snmp
-    - erlang-ssl
-    - erlang-syntax-tools
-    - erlang-tftp
-    - erlang-tools
-    - erlang-xmerl

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -92,6 +92,7 @@
     - erlang-xmerl
   when: erlang_version == "present"
 
+# Order is important when using pinned versions as have to do in order of dependencies
 - name: Install pinned erlang packages on {{ ansible_facts.distribution }}
   become: yes
   package:
@@ -107,17 +108,17 @@
     - erlang-base
     - erlang-asn1
     - erlang-crypto
+    - erlang-public-key
+    - erlang-mnesia
+    - erlang-runtime-tools
+    - erlang-ssl
     - erlang-eldap
     - erlang-ftp
+    - erlang-tftp
     - erlang-inets
-    - erlang-mnesia
+    - erlang-snmp
     - erlang-os-mon
     - erlang-parsetools
-    - erlang-public-key
-    - erlang-runtime-tools
-    - erlang-snmp
-    - erlang-ssl
     - erlang-syntax-tools
-    - erlang-tftp
     - erlang-tools
     - erlang-xmerl

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -76,7 +76,7 @@
 - name: Install latest erlang packages on {{ ansible_facts.distribution }}
   become: yes
   package:
-    name: "{{item}}"
+    name: "{{ item }}"
     state: present
   register: _eltask
   retries: 5
@@ -107,7 +107,7 @@
 - name: Install pinned erlang packages on {{ ansible_facts.distribution }}
   become: yes
   package:
-    name: "{{item}}={{erlang_version}}"
+    name: "{{ item }}={{ erlang_version }}"
     state: present
   register: _eltask
   retries: 5

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -37,10 +37,21 @@
   until: _task is succeeded
   tags: rabbitmq
 
-- name: apt | Add PackageCloud key
+- name: apt | Add CloudSmith RabbitMQ key
   become: yes
   apt_key:
-    url: "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey"
+    url: "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key"
+    state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
+  tags: rabbitmq
+
+- name: apt | Add CloudSmith erlang key
+  become: yes
+  apt_key:
+    url: "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key"
     state: present
   register: _task
   retries: 5
@@ -51,14 +62,14 @@
 - name: Add erlang repos
   become: yes
   apt_repository:
-    repo: "deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu {{ ansible_facts.distribution_release|lower }} main"
+    repo: "deb https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_facts.distribution_release|lower }} main"
     state: present
   tags: rabbitmq
 
 - name: Add rabbitmq repos
   become: yes
   apt_repository:
-    repo: "deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ {{ ansible_facts.distribution_release|lower }} main"
+    repo: "deb https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu {{ ansible_facts.distribution_release|lower }} main"
     state: present
   tags: rabbitmq
 

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -72,3 +72,16 @@
   delay: 3
   until: _eltask is succeeded
   tags: rabbitmq
+  when: erlang_version == "present"
+
+- name: Install latest erlang packages on {{ ansible_facts.distribution }}
+  become: yes
+  package:
+    name: "erlang={{erlang_version}}"
+    state: present
+  register: _eltask
+  retries: 5
+  delay: 3
+  until: _eltask is succeeded
+  tags: rabbitmq
+  when: erlang_version != "present"

--- a/roles/StackStorm.st2/tasks/auth.yml
+++ b/roles/StackStorm.st2/tasks/auth.yml
@@ -21,7 +21,7 @@
 - name: auth | Install auth pre-reqs (RedHat)
   become: yes
   yum:
-    name: 
+    name:
       - httpd-tools
       - "{{ passlib }}"
     state: present

--- a/roles/StackStorm.st2/tasks/auth.yml
+++ b/roles/StackStorm.st2/tasks/auth.yml
@@ -21,8 +21,7 @@
 - name: auth | Install auth pre-reqs (RedHat)
   become: yes
   yum:
-    name:
-      - httpd-tools
+    name: httpd-tools
     state: present
   register: _task
   retries: 5
@@ -35,8 +34,20 @@
   become: yes
   pip:
      name: passlib
+     executable: /usr/bin/pip3
      state: present
-  when: ansible_facts.os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version!='7'
+
+- name: auth | Install auth pre-reqs (RedHat)
+  become: yes
+  yum:
+    name: httpd-tools
+    state: present
+  register: _task
+  retries: 5
+  delay: 3
+  until: _task is succeeded
+  when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version=='7'
 
 - name: auth | Create htpasswd file
   become: true

--- a/roles/StackStorm.st2/tasks/auth.yml
+++ b/roles/StackStorm.st2/tasks/auth.yml
@@ -21,7 +21,9 @@
 - name: auth | Install auth pre-reqs (RedHat)
   become: yes
   yum:
-    name: httpd-tools
+    name: 
+      - httpd-tools
+      - "{{ passlib }}"
     state: present
   register: _task
   retries: 5
@@ -29,7 +31,8 @@
   until: _task is succeeded
   when: ansible_facts.os_family == 'RedHat'
 
-# Use pip to install passlib as no python38-passlib yum package available
+# Use pip to install passlib as no python38-passlib yum package available. Still need python3-passlib
+# installed as well though from above task
 - name: auth | Install pip pre-reqs (RedHat)
   become: yes
   pip:
@@ -37,17 +40,6 @@
      executable: /usr/bin/pip3
      state: present
   when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version!='7'
-
-- name: auth | Install auth pre-reqs (RedHat)
-  become: yes
-  yum:
-    name: "{{ passlib }}"
-    state: present
-  register: _task
-  retries: 5
-  delay: 3
-  until: _task is succeeded
-  when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version=='7'
 
 - name: auth | Create htpasswd file
   become: true

--- a/roles/StackStorm.st2/tasks/auth.yml
+++ b/roles/StackStorm.st2/tasks/auth.yml
@@ -23,12 +23,19 @@
   yum:
     name:
       - httpd-tools
-      - "{{ passlib }}"
     state: present
   register: _task
   retries: 5
   delay: 3
   until: _task is succeeded
+  when: ansible_facts.os_family == 'RedHat'
+
+# Use pip to install passlib as no python38-passlib yum package available
+- name: auth | Install pip pre-reqs (RedHat)
+  become: yes
+  pip:
+     name: passlib
+     state: present
   when: ansible_facts.os_family == 'RedHat'
 
 - name: auth | Create htpasswd file

--- a/roles/StackStorm.st2/tasks/auth.yml
+++ b/roles/StackStorm.st2/tasks/auth.yml
@@ -41,7 +41,7 @@
 - name: auth | Install auth pre-reqs (RedHat)
   become: yes
   yum:
-    name: httpd-tools
+    name: "{{ passlib }}"
     state: present
   register: _task
   retries: 5


### PR DESCRIPTION
Use the CloudSmith rabbitmq-erlang packages rather than the LaunchPad  erlang packages for Debian installations, so that we can specify a 24.x version of the rabbitmq-erlang. (25.x and 22.x are only available in LaunchPad for Debian and fail with latest rabbitMQ).

We no-longer want to use the latest 1.25 that is available in the rabbitmq-erlang repository, as this means that rabbitmq fails to install, and instead reports error:
```
fatal: [localhost]: FAILED! => {"attempts": 5, "cache_update_time": 1653987046, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"      install 'rabbitmq-server'' failed: E: Unable to correct problems, you have held broken packages.\n", "rc": 100, "stderr": "E: Unable to correct problems, you have held broken packages.\n", "stderr_lines": ["E: Unable to correct problems, you have held broken packages."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n rabbitmq-server : Depends: erlang-base (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or\n                            erlang-base-hipe (< 1:25.0) but it is not going to be installed or\n                            esl-erlang (< 1:25.0) but it is not installable\n                   Depends: erlang-crypto (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or\n                            esl-erlang (< 1:25.0) but it is not installable\n                   Depends: erlang-eldap (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or\n                            esl-erlang (< 1:25.0) but it is not installable\n                   Depends: erlang-inets (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or\n                            esl-erlang (< 1:25.0) but it is not installable\n                   Depends: erlang-mnesia (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or\n                            esl-erlang (< 1:25.0) but it is not installable\n                   Depends: erlang-os-mon (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or\n                            esl-erlang (< 1:25.0) but it is not installable\n                   Depends: erlang-parsetools (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or\n                            esl-erlang (< 1:25.0) but it is not installable\n                   Depends: erlang-public-key (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or\n                            esl-erlang (< 1:25.0) but it is not installable\n                   Depends: erlang-runtime-tools (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or\n                            esl-erlang (< 1:25.0) but it is not installable\n                   Depends: erlang-ssl (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or\n                            esl-erlang (< 1:25.0) but it is not installable\n                   Depends: erlang-syntax-tools (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or\n                            esl-erlang (< 1:25.0) but it is not installable\n                   Depends: erlang-tools (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or\n                            esl-erlang (< 1:25.0) but it is not installable\n                   Depends: erlang-xmerl (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or\n                            esl-erlang (< 1:25.0) but it is not installable\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "Some packages could not be installed. This may mean that you have", "requested an impossible situation or if you are using the unstable", "distribution that some required packages have not yet been created", "or been moved out of Incoming.", "The following information may help to resolve the situation:", "", "The following packages have unmet dependencies:", " rabbitmq-server : Depends: erlang-base (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or", "                            erlang-base-hipe (< 1:25.0) but it is not going to be installed or", "                            esl-erlang (< 1:25.0) but it is not installable", "                   Depends: erlang-crypto (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or", "                            esl-erlang (< 1:25.0) but it is not installable", "                   Depends: erlang-eldap (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or", "                            esl-erlang (< 1:25.0) but it is not installable", "                   Depends: erlang-inets (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or", "                            esl-erlang (< 1:25.0) but it is not installable", "                   Depends: erlang-mnesia (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or", "                            esl-erlang (< 1:25.0) but it is not installable", "                   Depends: erlang-os-mon (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or", "                            esl-erlang (< 1:25.0) but it is not installable", "                   Depends: erlang-parsetools (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or", "                            esl-erlang (< 1:25.0) but it is not installable", "                   Depends: erlang-public-key (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or", "                            esl-erlang (< 1:25.0) but it is not installable", "                   Depends: erlang-runtime-tools (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or", "                            esl-erlang (< 1:25.0) but it is not installable", "                   Depends: erlang-ssl (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or", "                            esl-erlang (< 1:25.0) but it is not installable", "                   Depends: erlang-syntax-tools (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or", "                            esl-erlang (< 1:25.0) but it is not installable", "                   Depends: erlang-tools (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or", "                            esl-erlang (< 1:25.0) but it is not installable", "                   Depends: erlang-xmerl (< 1:25.0) but 1:25.0-1rmq1ppa1~ubuntu18.04.1 is to be installed or", "                            esl-erlang (< 1:25.0) but it is not installable"]}
```

Resolves #312 