### PR TITLE
Need to install ansible-core on EL8

### DIFF
--- a/.kitchen-docker/rockylinux8/Dockerfile
+++ b/.kitchen-docker/rockylinux8/Dockerfile
@@ -13,3 +13,4 @@ RUN chmod 0600 /home/<%= @username %>/.ssh/authorized_keys
 RUN echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys
 RUN yum install -y ansible-core
 RUN ansible-galaxy collection install community.rabbitmq
+RUN ansible-galaxy collection install ansible.posix

--- a/.kitchen-docker/rockylinux8/Dockerfile
+++ b/.kitchen-docker/rockylinux8/Dockerfile
@@ -11,3 +11,4 @@ RUN touch /home/<%= @username %>/.ssh/authorized_keys
 RUN chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys
 RUN chmod 0600 /home/<%= @username %>/.ssh/authorized_keys
 RUN echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys
+RUN yum install -y ansible-core

--- a/.kitchen-docker/rockylinux8/Dockerfile
+++ b/.kitchen-docker/rockylinux8/Dockerfile
@@ -12,3 +12,4 @@ RUN chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys
 RUN chmod 0600 /home/<%= @username %>/.ssh/authorized_keys
 RUN echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys
 RUN yum install -y ansible-core
+RUN ansible-galaxy collection install community.rabbitmq

--- a/.kitchen-docker/rockylinux8/Dockerfile
+++ b/.kitchen-docker/rockylinux8/Dockerfile
@@ -12,5 +12,4 @@ RUN chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys
 RUN chmod 0600 /home/<%= @username %>/.ssh/authorized_keys
 RUN echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys
 RUN yum install -y ansible-core
-RUN ansible-galaxy collection install community.rabbitmq
-RUN ansible-galaxy collection install ansible.posix
+RUN ansible-galaxy collection install community.rabbitmq ansible.posix community.general


### PR DESCRIPTION
kitchen ansible provider always tries to install ansible, but that is no-longer available on EL8. 
Updated the el8 dockerfile to install ansible-core and the necessary collections that were in the old ansible package but not in ansible-core.