### PR TITLE
Remove centos7

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,11 +54,13 @@ jobs:
         os:
           - rockylinux8
           - ubuntu20
+        ansible-core:
+          - "2.11.12"
+        # Only run centos7 for stable, as not valid for new release
         include:
           - st2_repo: stable
             os: centos7
-        ansible-core:
-          - "2.11.12"
+            ansible-core: 2.11.12
 
     steps:
       - name: Checkout the repository

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,7 +52,6 @@ jobs:
           - stable
           - unstable
         os:
-          - centos7
           - rockylinux8
           - ubuntu20
         ansible-core:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,6 +54,9 @@ jobs:
         os:
           - rockylinux8
           - ubuntu20
+        include:
+          - st2_repo: stable
+            os: centos7
         ansible-core:
           - "2.11.12"
 


### PR DESCRIPTION
Run centos7 on stable only - as its still valid for 3.8.x release.
Resolves #334