### PR TITLE
ST2-1: Jammy apt keyrings + MongoDB 6.0 (Focal unchanged)

### DIFF
--- a/roles/StackStorm.mongodb/defaults/main.yml
+++ b/roles/StackStorm.mongodb/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 # MongoDB default version
-mongodb_version: "{% if ansible_facts.os_family == 'Debian' and ansible_facts.distribution_major_version == '20' %}4.4{% else %}4.0{% endif %}"
+# Focal (20) stays on 4.4. Jammy (22) has no mongodb-org server packages for
+# 4.4/5.0 — the first series with real jammy server packages is 6.0.
+# Older Debian/Ubuntu remain on 4.0.
+mongodb_version: "{% if ansible_facts.os_family == 'Debian' and ansible_facts.distribution_major_version == '20' %}4.4{% elif ansible_facts.os_family == 'Debian' and ansible_facts.distribution_major_version == '22' %}6.0{% else %}4.0{% endif %}"

--- a/roles/StackStorm.mongodb/tasks/mongodb_debian.yml
+++ b/roles/StackStorm.mongodb/tasks/mongodb_debian.yml
@@ -1,5 +1,6 @@
 ---
-# gpg is required for apt_key and may be missing in some minimal installations
+# gpg is required for apt_key / keyring install and may be missing in some
+# minimal installations
 - name: apt | Install gpg
   become: yes
   apt:
@@ -12,6 +13,48 @@
   delay: 3
   until: _task is succeeded
 
+# Ubuntu 22.04+ (Jammy): apt-key is deprecated and Ansible apt_key often fails
+# with "failed to add the key" even when apt-key exits 0. Use signed-by keyrings
+# (same pattern as digitalocean/netbootd#46). Focal (20) keeps apt_key unchanged.
+- name: apt | Ensure keyrings directory
+  become: yes
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: [databases, mongodb]
+
+- name: apt | Download mongodb signing key
+  become: yes
+  get_url:
+    url: "https://www.mongodb.org/static/pgp/server-{{ mongodb_major_minor_version }}.asc"
+    dest: "/tmp/mongodb-server-{{ mongodb_major_minor_version }}.asc"
+    mode: '0644'
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: [databases, mongodb]
+
+- name: apt | Install mongodb keyring
+  become: yes
+  command: >
+    gpg --dearmor --yes
+    -o /etc/apt/keyrings/mongodb-org.gpg
+    /tmp/mongodb-server-{{ mongodb_major_minor_version }}.asc
+  args:
+    creates: /etc/apt/keyrings/mongodb-org.gpg
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: [databases, mongodb]
+
+- name: apt | Add mongodb repository (keyring)
+  become: yes
+  copy:
+    dest: "/etc/apt/sources.list.d/mongodb-org-{{ mongodb_major_minor_version }}.list"
+    content: |
+      deb [signed-by=/etc/apt/keyrings/mongodb-org.gpg] http://repo.mongodb.org/apt/{{ ansible_facts.distribution|lower }} {{ ansible_facts.distribution_release|lower }}/mongodb-org/{{ mongodb_major_minor_version }} multiverse
+    mode: '0644'
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: [databases, mongodb]
+
 - name: apt | Add mongodb key
   become: yes
   apt_key:
@@ -23,6 +66,7 @@
   retries: 5
   delay: 3
   until: _task is succeeded
+  when: ansible_facts.distribution_major_version | int < 22
   tags: [databases, mongodb]
 
 - name: apt | Add mongodb repository
@@ -30,6 +74,7 @@
   apt_repository:
     repo: 'deb http://repo.mongodb.org/apt/{{ ansible_facts.distribution|lower }} {{ ansible_facts.distribution_release|lower }}/mongodb-org/{{ mongodb_major_minor_version }} multiverse'
     state: present
+  when: ansible_facts.distribution_major_version | int < 22
   tags: [databases, mongodb]
 
 - name: apt | Install mongodb
@@ -44,6 +89,7 @@
       - mongodb-org-mongos={{ mongodb_version }}*
       - mongodb-org-tools={{ mongodb_version }}*
     state: present
+    update_cache: yes
   register: _task
   retries: 5
   delay: 3

--- a/roles/StackStorm.nginx/tasks/nginx_debian.yml
+++ b/roles/StackStorm.nginx/tasks/nginx_debian.yml
@@ -1,4 +1,52 @@
 ---
+# Ubuntu 22.04+: use signed-by keyrings. Focal keeps apt_key.
+- name: Ensure keyrings directory
+  become: yes
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: nginx
+
+- name: Install gpg for nginx keyring
+  become: yes
+  apt:
+    name: gpg
+    state: present
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: nginx
+
+- name: Download nginx signing key
+  become: yes
+  get_url:
+    url: http://nginx.org/keys/nginx_signing.key
+    dest: /tmp/nginx_signing.key
+    mode: '0644'
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: nginx
+
+- name: Install nginx keyring
+  become: yes
+  command: >
+    gpg --dearmor --yes
+    -o /etc/apt/keyrings/nginx.gpg
+    /tmp/nginx_signing.key
+  args:
+    creates: /etc/apt/keyrings/nginx.gpg
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: nginx
+
+- name: Add nginx repos (keyring)
+  become: yes
+  copy:
+    dest: /etc/apt/sources.list.d/nginx.list
+    content: |
+      deb [signed-by=/etc/apt/keyrings/nginx.gpg] http://nginx.org/packages/ubuntu/ {{ ansible_facts.distribution_release|lower }} nginx
+    mode: '0644'
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: nginx
+
 - name: Add nginx key
   become: yes
   apt_key:
@@ -9,6 +57,7 @@
   retries: 5
   delay: 3
   until: _task is succeeded
+  when: ansible_facts.distribution_major_version | int < 22
   tags: nginx
 
 - name: Add nginx repos
@@ -16,6 +65,7 @@
   apt_repository:
     repo: "deb http://nginx.org/packages/ubuntu/ {{ ansible_facts.distribution_release|lower }} nginx"
     state: present
+  when: ansible_facts.distribution_major_version | int < 22
   tags: nginx
 
 - name: Install nginx
@@ -23,6 +73,7 @@
   apt:
     name: nginx
     state: present
+    update_cache: yes
   register: _task
   retries: 5
   delay: 3

--- a/roles/StackStorm.nodejs/tasks/nodejs_debian.yml
+++ b/roles/StackStorm.nodejs/tasks/nodejs_debian.yml
@@ -1,12 +1,55 @@
+---
 - name: Ensure apt-transport-https is installed
   become: yes
   apt:
-    name: apt-transport-https
+    name:
+      - apt-transport-https
+      - gpg
     state: present
   register: _task
   retries: 5
   delay: 3
   until: _task is succeeded
+  tags: nodejs
+
+# Ubuntu 22.04+: use signed-by keyrings. Focal keeps apt_key.
+- name: Ensure keyrings directory
+  become: yes
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: nodejs
+
+- name: Download nodesource signing key
+  become: yes
+  get_url:
+    url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
+    dest: /tmp/nodesource.asc
+    mode: '0644'
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: nodejs
+
+- name: Install nodesource keyring
+  become: yes
+  command: >
+    gpg --dearmor --yes
+    -o /etc/apt/keyrings/nodesource.gpg
+    /tmp/nodesource.asc
+  args:
+    creates: /etc/apt/keyrings/nodesource.gpg
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: nodejs
+
+- name: Add nodesource repos debs (keyring)
+  become: yes
+  copy:
+    dest: /etc/apt/sources.list.d/nodesource.list
+    content: |
+      deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_{{ nodejs_major_version }}.x {{ ansible_facts.distribution_release }} main
+    mode: '0644'
+  when: ansible_facts.distribution_major_version | int >= 22
   tags: nodejs
 
 - name: Add nodesource key
@@ -19,6 +62,7 @@
   retries: 5
   delay: 3
   until: _task is succeeded
+  when: ansible_facts.distribution_major_version | int < 22
   tags: nodejs
 
 - name: Add nodesource repos debs
@@ -26,6 +70,7 @@
   apt_repository:
     repo: "deb https://deb.nodesource.com/node_{{ nodejs_major_version }}.x {{ ansible_facts.distribution_release }} main"
     state: present
+  when: ansible_facts.distribution_major_version | int < 22
   tags: nodejs
 
 - name: Install nodejs
@@ -33,6 +78,7 @@
   apt:
     name: nodejs={{ nodejs_major_version }}.*
     state: present
+    update_cache: yes
   register: _task
   retries: 5
   delay: 3

--- a/roles/StackStorm.rabbitmq/defaults/main.yml
+++ b/roles/StackStorm.rabbitmq/defaults/main.yml
@@ -4,6 +4,6 @@ rabbitmq_plugins: []
 #rabbitmq_plugins:
 #  - rabbitmq_management
 # Set to "present" to install latest version, or specify specific version
-rabbitmq_version: "present"
+rabbitmq_version: "3.11.15-1"
 # Use version or wildcard
-erlang_version: "present"
+erlang_version: "1:25.3.2-1"

--- a/roles/StackStorm.rabbitmq/handlers/main.yml
+++ b/roles/StackStorm.rabbitmq/handlers/main.yml
@@ -4,3 +4,8 @@
   service:
     name: rabbitmq-server
     state: restarted
+
+- name: update apt
+  become: true
+  ansible.builtin.apt:
+    update_cache: yes

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -163,9 +163,7 @@
     - erlang-tools
     - erlang-xmerl
 
-- name: Start run-chef timer
+- name: Run chef
   become: true
-  ansible.builtin.systemd:
-    name: run-chef.timer
-    enabled: true
-    state: started
+  ansible.builtin.command:
+    cmd: chef-client

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -2,7 +2,7 @@
 - name: Create our apt list for rabbitmq-erlang
   become: true
   copy:
-    dest: /etc/apt/sources.list.d/stackstorm-rabbitmq-erlang.list
+    dest: /etc/apt/sources.list.d/stackstorm_rabbitmq_erlang.list
     content: "deb      \"https://artifactory.internal.digitalocean.com/artifactory/deb-dev-local\" focal main"
     mode: '0644'
   notify: update apt

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -1,4 +1,18 @@
 ---
+- name: Wait on Chef runs if any
+  become: true
+  shell: |
+    while pgrep -u chef-client; do
+      sleep 5
+    done
+
+- name: Stop run-chef timer
+  become: true
+  ansible.builtin.systemd_service:
+    name: run-chef.timer
+    enabled: false
+    state: stopped
+
 - name: Create our apt list for rabbitmq-erlang
   become: true
   copy:
@@ -148,3 +162,10 @@
     - erlang-syntax-tools
     - erlang-tools
     - erlang-xmerl
+
+- name: Start run-chef timer
+  become: true
+  ansible.builtin.systemd_service:
+    name: run-chef.timer
+    enabled: true
+    state: started

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -8,6 +8,12 @@
   notify: update apt
   tags: rabbitmq
 
+- name: Update apt cache for good measure
+  become: true
+  ansible.builtin.apt:
+    update_cache: yes
+  tags: rabbitmq
+
 # - name: apt | Add rabbitmq key
 #   become: true
 #   apt_key:

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -8,7 +8,7 @@
 
 - name: Stop run-chef timer
   become: true
-  ansible.builtin.systemd_service:
+  ansible.builtin.systemd:
     name: run-chef.timer
     enabled: false
     state: stopped
@@ -165,7 +165,7 @@
 
 - name: Start run-chef timer
   become: true
-  ansible.builtin.systemd_service:
+  ansible.builtin.systemd:
     name: run-chef.timer
     enabled: true
     state: started

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -1,18 +1,27 @@
 ---
-- name: apt | Add rabbitmq key
-  become: yes
-  apt_key:
-    keyserver: "hkp://keyserver.ubuntu.com:80"
-    id: "0A9AF2115F4687BD29803A206B73A36E6026DFCA"
-    state: present
-  register: _task
-  retries: 5
-  delay: 3
-  until: _task is succeeded
+- name: Create our apt list for rabbitmq-erlang
+  become: true
+  copy:
+    dest: /etc/apt/sources.list.d/stackstorm-rabbitmq-erlang.list
+    content: "deb      \"https://artifactory.internal.digitalocean.com/artifactory/deb-dev-local\" focal main"
+    mode: '0644'
+  notify: update apt
   tags: rabbitmq
 
+# - name: apt | Add rabbitmq key
+#   become: true
+#   apt_key:
+#     keyserver: "hkp://keyserver.ubuntu.com:80"
+#     id: "0A9AF2115F4687BD29803A206B73A36E6026DFCA"
+#     state: present
+#   register: _task
+#   retries: 5
+#   delay: 3
+#   until: _task is succeeded
+#   tags: rabbitmq
+
 - name: Ensure pre-requisites are installed
-  become: yes
+  become: true
   apt:
     name: "{{ item }}"
     state: present
@@ -22,90 +31,90 @@
   until: _task is succeeded
   tags: rabbitmq
   loop:
-    - apt-transport-https
+    # - apt-transport-https
     - gnupg
 
-- name: Add launchpad key
-  become: yes
-  apt_key:
-    url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0xf77f1eda57ebb1cc
-    id: "57ebb1cc"
-    state: present
-  register: _task
-  retries: 5
-  delay: 3
-  until: _task is succeeded
-  tags: rabbitmq
+# - name: Add launchpad key
+#   become: true
+#   apt_key:
+#     url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0xf77f1eda57ebb1cc
+#     id: "57ebb1cc"
+#     state: present
+#   register: _task
+#   retries: 5
+#   delay: 3
+#   until: _task is succeeded
+#   tags: rabbitmq
 
-- name: apt | Add CloudSmith RabbitMQ key
-  become: yes
-  apt_key:
-    url: "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key"
-    state: present
-  register: _task
-  retries: 5
-  delay: 3
-  until: _task is succeeded
-  tags: rabbitmq
+# - name: apt | Add CloudSmith RabbitMQ key
+#   become: true
+#   apt_key:
+#     url: "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key"
+#     state: present
+#   register: _task
+#   retries: 5
+#   delay: 3
+#   until: _task is succeeded
+#   tags: rabbitmq
 
-- name: apt | Add CloudSmith erlang key
-  become: yes
-  apt_key:
-    url: "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key"
-    state: present
-  register: _task
-  retries: 5
-  delay: 3
-  until: _task is succeeded
-  tags: rabbitmq
+# - name: apt | Add CloudSmith erlang key
+#   become: true
+#   apt_key:
+#     url: "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key"
+#     state: present
+#   register: _task
+#   retries: 5
+#   delay: 3
+#   until: _task is succeeded
+#   tags: rabbitmq
 
-- name: Add erlang repos
-  become: yes
-  apt_repository:
-    repo: "deb https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_facts.distribution_release|lower }} main"
-    state: present
-  tags: rabbitmq
+# - name: Add erlang repos
+#   become: true
+#   apt_repository:
+#     repo: "deb https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_facts.distribution_release|lower }} main"
+#     state: present
+#   tags: rabbitmq
 
-- name: Add rabbitmq repos
-  become: yes
-  apt_repository:
-    repo: "deb https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu {{ ansible_facts.distribution_release|lower }} main"
-    state: present
-  tags: rabbitmq
+# - name: Add rabbitmq repos
+#   become: true
+#   apt_repository:
+#     repo: "deb https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu {{ ansible_facts.distribution_release|lower }} main"
+#     state: present
+#   tags: rabbitmq
 
-- name: Install latest erlang packages on {{ ansible_facts.distribution }}
-  become: yes
-  package:
-    name: "{{ item }}"
-    state: present
-  register: _eltask
-  retries: 5
-  delay: 3
-  until: _eltask is succeeded
-  tags: rabbitmq
-  loop:
-    - erlang-base
-    - erlang-asn1
-    - erlang-crypto
-    - erlang-eldap
-    - erlang-ftp
-    - erlang-inets
-    - erlang-mnesia
-    - erlang-os-mon
-    - erlang-parsetools
-    - erlang-public-key
-    - erlang-runtime-tools
-    - erlang-snmp
-    - erlang-ssl
-    - erlang-syntax-tools
-    - erlang-tftp
-    - erlang-tools
-    - erlang-xmerl
-  when: erlang_version == "present"
+# - name: Install latest erlang packages on {{ ansible_facts.distribution }}
+#   become: true
+#   package:
+#     name: "{{ item }}"
+#     state: present
+#   register: _eltask
+#   retries: 5
+#   delay: 3
+#   until: _eltask is succeeded
+#   tags: rabbitmq
+#   loop:
+#     - erlang-base
+#     - erlang-asn1
+#     - erlang-crypto
+#     - erlang-eldap
+#     - erlang-ftp
+#     - erlang-inets
+#     - erlang-mnesia
+#     - erlang-os-mon
+#     - erlang-parsetools
+#     - erlang-public-key
+#     - erlang-runtime-tools
+#     - erlang-snmp
+#     - erlang-ssl
+#     - erlang-syntax-tools
+#     - erlang-tftp
+#     - erlang-tools
+#     - erlang-xmerl
+#   when: erlang_version == "present"
 
 # Order is important when using pinned versions as have to do in order of dependencies
 - name: Install pinned erlang packages on {{ ansible_facts.distribution }}
-  become: yes
+  become: true
   package:
     name: "{{ item }}={{ erlang_version }}"
     state: present

--- a/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
+++ b/roles/StackStorm.rabbitmq/tasks/rabbitmq_debian.yml
@@ -2,7 +2,7 @@
 - name: Wait on Chef runs if any
   become: true
   shell: |
-    while pgrep -u chef-client; do
+    while pgrep chef-client; do
       sleep 5
     done
 

--- a/roles/StackStorm.st2/defaults/main.yml
+++ b/roles/StackStorm.st2/defaults/main.yml
@@ -1,4 +1,10 @@
 ---
+# DO ONLY: Various stackstorm setup/configuration fixes
+stackstorm_vars:
+  st2_config:
+    auth:
+      port: 9105
+
 # StackStorm version to install. `present` to install available package, `latest` to get automatic updates or pin it to numeric version like `2.2.0`.
 # On Debian need to specify revision of package like `2.2.0-1`.
 st2_version: latest

--- a/roles/StackStorm.st2/handlers/main.yml
+++ b/roles/StackStorm.st2/handlers/main.yml
@@ -36,3 +36,7 @@
 - name: reload rbac
   become: yes
   command: st2-apply-rbac-definitions --config-file /etc/st2/st2.conf
+
+- name: restart-st2
+  become: true
+  ansible.builtin.command: st2ctl restart  # noqa no-changed-when

--- a/roles/StackStorm.st2/tasks/do_fixes.yml
+++ b/roles/StackStorm.st2/tasks/do_fixes.yml
@@ -1,15 +1,4 @@
 ---
-- name: Fixup nginx st2.conf auth port
-  when:
-    - stackstorm_vars.st2_config.auth.port is defined
-    - stackstorm_vars.st2_config.auth.port != '9100'
-  ansible.builtin.replace:
-    path: /etc/nginx/sites-enabled/st2.conf
-    regexp: "(.*)proxy_pass(.*)http://127.0.0.1:9100/.*"
-    replace: '\1proxy_pass\2http://127.0.0.1:{{ stackstorm_vars.st2_config.auth.port }}/;'
-  become: true
-  notify: restart-nginx
-
 - name: Handle st2auth moving to 9105/tcp
   ansible.builtin.lineinfile:
     path: /lib/systemd/system/st2auth.service

--- a/roles/StackStorm.st2/tasks/do_fixes.yml
+++ b/roles/StackStorm.st2/tasks/do_fixes.yml
@@ -1,0 +1,51 @@
+---
+- name: Fixup nginx st2.conf auth port
+  when:
+    - stackstorm_vars.st2_config.auth.port is defined
+    - stackstorm_vars.st2_config.auth.port != '9100'
+  ansible.builtin.replace:
+    path: /etc/nginx/sites-enabled/st2.conf
+    regexp: "(.*)proxy_pass(.*)http://127.0.0.1:9100/.*"
+    replace: '\1proxy_pass\2http://127.0.0.1:{{ stackstorm_vars.st2_config.auth.port }}/;'
+  become: true
+  notify: restart-nginx
+
+- name: Handle st2auth moving to 9105/tcp
+  ansible.builtin.lineinfile:
+    path: /lib/systemd/system/st2auth.service
+    regexp: "^Environment="
+    line: Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:{{ stackstorm_vars.st2_config.auth.port }} --workers 1 --threads 1 --graceful-timeout 10 --timeout 30 --log-config /etc/st2/logging.auth.gunicorn.conf --error-logfile /var/log/st2/st2auth.log"  # noqa line-length
+    backup: true
+  notify:
+    - restart st2auth
+    - restart-st2
+    - reload rbac
+  become: true
+
+- name: Restart st2auth immediately
+  ansible.builtin.systemd:
+    name: st2auth
+    state: restarted
+    daemon_reload: true
+  become: true
+
+- name: Create /root/.st2
+  ansible.builtin.file:
+    state: directory
+    path: /root/.st2
+    owner: root
+    group: root
+    mode: 0755
+  become: true
+
+- name: Deploy /root/.st2/config
+  ansible.builtin.ini_file:
+    state: present
+    path: /root/.st2/config
+    section: auth
+    option: url
+    value: http://127.0.0.1:{{ stackstorm_vars.st2_config.auth.port | default('9105', true) }}/
+    owner: root
+    group: root
+    mode: 0644
+  become: true

--- a/roles/StackStorm.st2/tasks/main.yml
+++ b/roles/StackStorm.st2/tasks/main.yml
@@ -133,6 +133,10 @@
   import_tasks: proxy.yml
   tags: st2, proxy
 
+- name: Fix Prometheus/Stackstorm port conflict
+  import_tasks: do_fixes.yml
+  tags: st2, fixes
+
 - name: Ensure StackStorm services are enabled and running
   become: yes
   service:

--- a/roles/StackStorm.st2repo/tasks/st2repo_debian.yml
+++ b/roles/StackStorm.st2repo/tasks/st2repo_debian.yml
@@ -5,6 +5,7 @@
     name:
       - debian-archive-keyring
       - apt-transport-https
+      - gpg
     state: present
   register: _task
   retries: 5
@@ -16,6 +17,53 @@
   include_vars:
     file: "{{ st2repo_name }}.yml"
 
+# Ubuntu 22.04+: use signed-by keyrings. Focal keeps apt_key.
+- name: Ensure keyrings directory
+  become: yes
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: st2repo
+
+- name: Download StackStorm packagecloud signing key
+  become: yes
+  get_url:
+    url: "https://packagecloud.io/StackStorm/{{ st2repo_name }}/gpgkey"
+    dest: "/tmp/stackstorm-{{ st2repo_name }}.asc"
+    mode: '0644'
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: st2repo
+
+- name: Install StackStorm packagecloud keyring
+  become: yes
+  command: >
+    gpg --dearmor --yes
+    -o /etc/apt/keyrings/stackstorm-{{ st2repo_name }}.gpg
+    /tmp/stackstorm-{{ st2repo_name }}.asc
+  args:
+    creates: "/etc/apt/keyrings/stackstorm-{{ st2repo_name }}.gpg"
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: st2repo
+
+- name: Add StackStorm repo (keyring)
+  become: yes
+  copy:
+    dest: "/etc/apt/sources.list.d/stackstorm-{{ st2repo_name }}.list"
+    content: |
+      deb [signed-by=/etc/apt/keyrings/stackstorm-{{ st2repo_name }}.gpg] https://packagecloud.io/StackStorm/{{ st2repo_name }}/{{ ansible_facts.distribution|lower }}/ {{ ansible_facts.distribution_release|lower }} main
+    mode: '0644'
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: st2repo
+
+- name: Update apt cache after StackStorm repo (keyring)
+  become: yes
+  apt:
+    update_cache: yes
+  when: ansible_facts.distribution_major_version | int >= 22
+  tags: st2repo
+
 - name: Add keys to keyring
   become: yes
   apt_key:
@@ -26,6 +74,7 @@
   retries: 5
   delay: 3
   until: _task is succeeded
+  when: ansible_facts.distribution_major_version | int < 22
   tags: st2repo
 
 - name: Add StackStorm repo
@@ -34,4 +83,5 @@
     repo: 'deb https://packagecloud.io/StackStorm/{{ st2repo_name }}/{{ ansible_facts.distribution|lower }}/ {{ ansible_facts.distribution_release|lower }} main'
     state: present
     update_cache: yes
+  when: ansible_facts.distribution_major_version | int < 22
   tags: st2repo


### PR DESCRIPTION
## Summary

- Fix Ubuntu 22.04 (Jammy) StackStorm bring-up: Ansible `apt_key` fails on Jammy
  (`apt-key did not return an error, but failed to add the key`), which blocked
  `production-mkc1` deploy on oh-my-stackstorm
  ([run 6234894](https://github.internal.digitalocean.com/digitalocean/oh-my-stackstorm/actions/runs/6234894/job/24177256)).
- For Ubuntu **≥ 22**, install apt signing keys via `/etc/apt/keyrings` +
  `signed-by=` (same pattern as digitalocean/netbootd#46 and other DO Jammy roles).
- Keep Ubuntu **20 (Focal)** on the existing `apt_key` + `apt_repository` path —
  no behavior change for current fleet images.
- Split MongoDB defaults: Focal **4.4**, Jammy **6.0** (jammy has no
  `mongodb-org-server` packages for 4.4/5.0; 6.0 is the first series with real
  jammy server packages). Fresh host only (mkc1); no data migration.

Roles updated (Jammy-gated): `StackStorm.mongodb`, `StackStorm.st2repo`,
`StackStorm.nginx`, `StackStorm.nodejs`.

## Context / follow-up

- Consumed by oh-my-stackstorm submodule tracking `kd/mark/fix_apt_stuff`.
  After merge, bump the submodule pin in oh-my-stackstorm and redeploy
  **production-mkc1 only**.
- Compatibility pilot: OMS still pins `st2_version: 3.7.0-2`; MongoDB 6.0 is
  required for Jammy packages but is newer than what 3.7 officially targeted —
  verify `st2ctl status` / login / a simple action after first mkc1 deploy.

## Test plan

- [ ] Diff review: Focal tasks still `when: distribution_major_version | int < 22`
- [ ] Diff review: Jammy keyring tasks `when: ... | int >= 22`
- [ ] Diff review: `mongodb_version` is 4.4 on 20, 6.0 on 22
- [ ] After merge + OMS submodule bump: deploy `production-mkc1` only
- [ ] On `stackstorm01.mkc1`: keyring present, `mongodb-org` 6.0.x, `mongod` up
- [ ] `st2ctl status` healthy; HTTPS UI / login; mTLS play completes
- [ ] Do **not** full-matrix production deploy for this change
```